### PR TITLE
Configure the Dataset Viewer on HF

### DIFF
--- a/dataclaw/cli.py
+++ b/dataclaw/cli.py
@@ -462,6 +462,9 @@ tags:
   - agentic-coding
 {model_tags}
 pretty_name: Coding Agent Conversations
+configs:
+- config_name: default
+  data_files: conversations.jsonl
 ---
 
 # Coding Agent Conversation Logs


### PR DESCRIPTION
Add configuration for default data files in CLI.

Same addition as suggested in https://huggingface.co/datasets/peteromallet/dataclaw-peteromallet/discussions/1