### PR TITLE
Add Gemini CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **This is a performance art project.** Anthropic built their models on the world's freely shared information, then introduced increasingly [dystopian data policies](https://www.anthropic.com/news/detecting-and-preventing-distillation-attacks) to stop anyone else from doing the same with their data — pulling up the ladder behind them. DataClaw lets you throw the ladder back down. The dataset it produces is yours to share.
 
-Turn your Claude Code and Codex conversation history into structured data and publish it to Hugging Face with a single command. DataClaw parses session logs, redacts secrets and PII, and uploads the result as a ready-to-use dataset.
+Turn your Claude Code, Codex, and Gemini CLI conversation history into structured data and publish it to Hugging Face with a single command. DataClaw parses session logs, redacts secrets and PII, and uploads the result as a ready-to-use dataset.
 
 ![DataClaw](dataclaw.jpeg)
 
@@ -13,7 +13,7 @@ Every export is tagged **`dataclaw`** on Hugging Face. Together, they may someda
 Paste this into Claude Code, Codex, or any coding agent:
 
 ```
-Help me export my Claude Code and Codex conversation history to Hugging Face using DataClaw.
+Help me export my Claude Code, Codex, and Gemini CLI conversation history to Hugging Face using DataClaw.
 Install it, set up the skill, then walk me through the process.
 
 STEP 1 — INSTALL
@@ -29,12 +29,12 @@ STEP 3 — START
   Every dataclaw command outputs next_steps in its JSON — follow them through the entire flow.
 
 STEP 3A — CHOOSE SOURCE SCOPE (REQUIRED BEFORE EXPORT)
-  Ask the user explicitly: Claude Code, Codex, or both?
-  dataclaw config --source "claude|codex|both"
+  Ask the user explicitly: Claude Code, Codex, Gemini CLI, or all?
+  dataclaw config --source "claude|codex|gemini|all"
   Do not export until source scope is explicitly confirmed.
 
 STEP 3B — PRESENT ALL FOLDERS (REQUIRED BEFORE EXPORT)
-  dataclaw list --source "claude|codex|both"
+  dataclaw list --source "claude|codex|gemini|all"
   Send the FULL project/folder list to the user in a message (name, source, sessions, size, excluded).
   Ask which projects to exclude.
   dataclaw config --exclude "project1,project2" OR dataclaw config --confirm-projects
@@ -69,8 +69,8 @@ huggingface-cli login --token YOUR_TOKEN
 
 # See your projects
 dataclaw prep
-dataclaw config --source both  # REQUIRED: choose claude, codex, or both
-dataclaw list --source both  # Present full list and confirm folder scope before export
+dataclaw config --source all  # REQUIRED: choose claude, codex, gemini, or all
+dataclaw list --source all  # Present full list and confirm folder scope before export
 
 # Configure
 dataclaw config --repo username/my-personal-codex-data
@@ -105,23 +105,25 @@ dataclaw export --publish-attestation "User explicitly approved publishing to Hu
 |---------|-------------|
 | `dataclaw status` | Show current stage and next steps (JSON) |
 | `dataclaw prep` | Discover projects, check HF auth, output JSON |
-| `dataclaw prep --source both` | Prep with both Claude + Codex explicitly selected |
+| `dataclaw prep --source all` | Prep with Claude, Codex, and Gemini explicitly selected |
+| `dataclaw prep --source gemini` | Prep using only Gemini CLI sessions |
 | `dataclaw prep --source codex` | Prep using only Codex sessions |
 | `dataclaw prep --source claude` | Prep using only Claude Code sessions |
 | `dataclaw list` | List all projects with exclusion status |
-| `dataclaw list --source both` | List both Claude and Codex projects |
+| `dataclaw list --source all` | List Claude, Codex, and Gemini projects |
 | `dataclaw list --source codex` | List only Codex projects |
 | `dataclaw config` | Show current config |
 | `dataclaw config --repo user/my-personal-codex-data` | Set HF repo |
-| `dataclaw config --source both` | REQUIRED source scope selection (`claude`, `codex`, or `both`) |
+| `dataclaw config --source all` | REQUIRED source scope selection (`claude`, `codex`, `gemini`, or `all`) |
 | `dataclaw config --exclude "a,b"` | Add excluded projects (appends) |
 | `dataclaw config --redact "str1,str2"` | Add strings to always redact (appends) |
 | `dataclaw config --redact-usernames "u1,u2"` | Add usernames to anonymize (appends) |
 | `dataclaw config --confirm-projects` | Mark project selection as confirmed |
 | `dataclaw export --no-push` | Export locally only (always do this first) |
-| `dataclaw export --source both --no-push` | Export Claude + Codex sessions locally |
+| `dataclaw export --source all --no-push` | Export Claude, Codex, and Gemini sessions locally |
 | `dataclaw export --source codex --no-push` | Export only Codex sessions locally |
 | `dataclaw export --source claude --no-push` | Export only Claude Code sessions locally |
+| `dataclaw export --source gemini --no-push` | Export only Gemini CLI sessions locally |
 | `dataclaw confirm --full-name "NAME" --attest-full-name "..." --attest-sensitive "..." --attest-manual-scan "..."` | Scan for PII, run exact-name privacy check, verify review attestations, unlock pushing |
 | `dataclaw confirm --skip-full-name-scan --attest-full-name "..." --attest-sensitive "..." --attest-manual-scan "..."` | Skip exact-name scan when user declines sharing full name (requires skip attestation) |
 | `dataclaw export --publish-attestation "..."` | Export and push (requires `dataclaw confirm` first) |

--- a/dataclaw/config.py
+++ b/dataclaw/config.py
@@ -13,7 +13,7 @@ class DataClawConfig(TypedDict, total=False):
     """Expected shape of the config dict."""
 
     repo: str | None
-    source: str | None  # "claude" | "codex" | "both"
+    source: str | None  # "claude" | "codex" | "gemini" | "all"
     excluded_projects: list[str]
     redact_strings: list[str]
     redact_usernames: list[str]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -400,7 +400,7 @@ class TestListProjects:
         monkeypatch.setattr("dataclaw.cli.discover_projects", lambda: [])
         list_projects()
         captured = capsys.readouterr()
-        assert "No Claude Code or Codex sessions" in captured.out
+        assert "No Claude Code, Codex, or Gemini CLI sessions" in captured.out
 
     def test_source_filter_codex(self, monkeypatch, capsys):
         monkeypatch.setattr(
@@ -579,7 +579,7 @@ class TestWorkflowGateMessages:
         assert payload["full_name_scan"]["skipped"] is True
 
     def test_push_before_confirm_shows_step_process(self, monkeypatch, capsys):
-        monkeypatch.setattr("dataclaw.cli.load_config", lambda: {"stage": "review", "source": "both"})
+        monkeypatch.setattr("dataclaw.cli.load_config", lambda: {"stage": "review", "source": "all"})
         monkeypatch.setattr("sys.argv", ["dataclaw", "export"])
         with pytest.raises(SystemExit):
             main()
@@ -602,7 +602,7 @@ class TestWorkflowGateMessages:
                 }
             ],
         )
-        monkeypatch.setattr("dataclaw.cli.load_config", lambda: {"source": "both"})
+        monkeypatch.setattr("dataclaw.cli.load_config", lambda: {"source": "all"})
         monkeypatch.setattr("sys.argv", ["dataclaw", "export", "--no-push"])
         with pytest.raises(SystemExit):
             main()
@@ -626,8 +626,8 @@ class TestWorkflowGateMessages:
         assert payload["error"] == "Source scope is not confirmed yet."
         assert payload["blocked_on_step"] == "Step 2/6"
         assert len(payload["process_steps"]) == 6
-        assert payload["allowed_sources"] == ["both", "claude", "codex"]
-        assert payload["next_command"] == "dataclaw config --source both"
+        assert payload["allowed_sources"] == ["all", "both", "claude", "codex", "gemini"]
+        assert payload["next_command"] == "dataclaw config --source all"
 
     def test_configure_next_steps_require_full_folder_presentation(self):
         steps, _next = _build_status_next_steps(


### PR DESCRIPTION
## Summary

- Adds Gemini CLI session discovery and parsing (`~/.gemini/tmp/*/chats/session-*.json`)
- Renames source option `"both"` to `"all"` with **backward compatibility** — existing configs with `"both"` still work
- Resolves Gemini's SHA-256 hashed project directory names back to human-readable folder names
- Updates all tests for the new source options (256 passing)

Based on PR #2 by @woct0rdho, with:
- Merge conflict resolution against current main (PRs #6, #7)
- Backward compatibility so `"both"` in existing configs doesn't break
- Test updates for the `"both"` → `"all"` rename and new `"gemini"` source

## Test plan

- [x] All 256 tests pass
- [x] `discover_projects()` runs cleanly with no Gemini data in new format (graceful empty result)
- [ ] Test with actual Gemini CLI data in `chats/session-*.json` format

🤖 Generated with [Claude Code](https://claude.com/claude-code)