### PR TITLE
Add OpenCode source parsing support

### DIFF
--- a/dataclaw/config.py
+++ b/dataclaw/config.py
@@ -3,7 +3,7 @@
 import json
 import sys
 from pathlib import Path
-from typing import TypedDict
+from typing import TypedDict, cast
 
 CONFIG_DIR = Path.home() / ".dataclaw"
 CONFIG_FILE = CONFIG_DIR / "config.json"
@@ -20,6 +20,10 @@ class DataClawConfig(TypedDict, total=False):
     last_export: dict
     stage: str | None  # "auth" | "configure" | "review" | "confirmed" | "done"
     projects_confirmed: bool  # True once user has addressed folder exclusions
+    review_attestations: dict
+    review_verification: dict
+    last_confirm: dict
+    publish_attestation: str
 
 
 DEFAULT_CONFIG: DataClawConfig = {
@@ -35,10 +39,10 @@ def load_config() -> DataClawConfig:
         try:
             with open(CONFIG_FILE) as f:
                 stored = json.load(f)
-            return {**DEFAULT_CONFIG, **stored}
+            return cast(DataClawConfig, {**DEFAULT_CONFIG, **stored})
         except (json.JSONDecodeError, OSError) as e:
             print(f"Warning: could not read {CONFIG_FILE}: {e}", file=sys.stderr)
-    return dict(DEFAULT_CONFIG)
+    return cast(DataClawConfig, dict(DEFAULT_CONFIG))
 
 
 def save_config(config: DataClawConfig) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -400,7 +400,7 @@ class TestListProjects:
         monkeypatch.setattr("dataclaw.cli.discover_projects", lambda: [])
         list_projects()
         captured = capsys.readouterr()
-        assert "No Claude Code, Codex, or Gemini CLI sessions" in captured.out
+        assert "No Claude Code, Codex, Gemini CLI, or OpenCode sessions" in captured.out
 
     def test_source_filter_codex(self, monkeypatch, capsys):
         monkeypatch.setattr(
@@ -626,7 +626,7 @@ class TestWorkflowGateMessages:
         assert payload["error"] == "Source scope is not confirmed yet."
         assert payload["blocked_on_step"] == "Step 2/6"
         assert len(payload["process_steps"]) == 6
-        assert payload["allowed_sources"] == ["all", "both", "claude", "codex", "gemini"]
+        assert payload["allowed_sources"] == ["all", "both", "claude", "codex", "gemini", "opencode"]
         assert payload["next_command"] == "dataclaw config --source all"
 
     def test_configure_next_steps_require_full_folder_presentation(self):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,6 +1,7 @@
 """Tests for dataclaw.parser — JSONL parsing and project discovery."""
 
 import json
+import sqlite3
 
 import pytest
 
@@ -392,9 +393,42 @@ class TestParseSessionFile:
 
 class TestDiscoverProjects:
     def _disable_codex(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("dataclaw.parser.PROJECTS_DIR", tmp_path / "no-claude-projects")
         monkeypatch.setattr("dataclaw.parser.CODEX_SESSIONS_DIR", tmp_path / "no-codex-sessions")
         monkeypatch.setattr("dataclaw.parser.CODEX_ARCHIVED_DIR", tmp_path / "no-codex-archived")
         monkeypatch.setattr("dataclaw.parser._CODEX_PROJECT_INDEX", {})
+        monkeypatch.setattr("dataclaw.parser.GEMINI_DIR", tmp_path / "no-gemini")
+        monkeypatch.setattr("dataclaw.parser.OPENCODE_DB_PATH", tmp_path / "no-opencode.db")
+        monkeypatch.setattr("dataclaw.parser._OPENCODE_PROJECT_INDEX", {})
+
+    def _write_opencode_db(self, db_path):
+        conn = sqlite3.connect(db_path)
+        conn.execute(
+            "CREATE TABLE session ("
+            "id TEXT PRIMARY KEY, "
+            "directory TEXT, "
+            "time_created INTEGER, "
+            "time_updated INTEGER"
+            ")"
+        )
+        conn.execute(
+            "CREATE TABLE message ("
+            "id TEXT PRIMARY KEY, "
+            "session_id TEXT, "
+            "time_created INTEGER, "
+            "data TEXT"
+            ")"
+        )
+        conn.execute(
+            "CREATE TABLE part ("
+            "id TEXT PRIMARY KEY, "
+            "message_id TEXT, "
+            "time_created INTEGER, "
+            "data TEXT"
+            ")"
+        )
+        conn.commit()
+        return conn
 
     def test_with_projects(self, tmp_path, monkeypatch, mock_anonymizer):
         self._disable_codex(tmp_path, monkeypatch)
@@ -451,6 +485,7 @@ class TestDiscoverProjects:
         assert parse_project_sessions("nope", mock_anonymizer) == []
 
     def test_discover_codex_projects(self, tmp_path, monkeypatch):
+        self._disable_codex(tmp_path, monkeypatch)
         projects_dir = tmp_path / "projects"
         monkeypatch.setattr("dataclaw.parser.PROJECTS_DIR", projects_dir / "nonexistent")
 
@@ -645,6 +680,108 @@ class TestDiscoverProjects:
         paragraphs = [p.strip() for p in thinking.split("\n\n") if p.strip()]
         assert paragraphs == ["Planning fix", "Reading code"]
 
+    def test_discover_opencode_projects(self, tmp_path, monkeypatch):
+        self._disable_codex(tmp_path, monkeypatch)
+        db_path = tmp_path / "opencode.db"
+        conn = self._write_opencode_db(db_path)
+        conn.execute(
+            "INSERT INTO session (id, directory, time_created, time_updated) VALUES (?, ?, ?, ?)",
+            ("ses_1", "/Users/testuser/work/repo", 1706000000000, 1706000002000),
+        )
+        conn.commit()
+        conn.close()
+
+        monkeypatch.setattr("dataclaw.parser.OPENCODE_DB_PATH", db_path)
+        monkeypatch.setattr("dataclaw.parser._OPENCODE_PROJECT_INDEX", {})
+
+        projects = discover_projects()
+        assert len(projects) == 1
+        assert projects[0]["source"] == "opencode"
+        assert projects[0]["display_name"] == "opencode:repo"
+
+    def test_parse_opencode_project_sessions(self, tmp_path, monkeypatch, mock_anonymizer):
+        self._disable_codex(tmp_path, monkeypatch)
+        db_path = tmp_path / "opencode.db"
+        conn = self._write_opencode_db(db_path)
+
+        session_id = "ses_1"
+        cwd = "/Users/testuser/work/repo"
+        conn.execute(
+            "INSERT INTO session (id, directory, time_created, time_updated) VALUES (?, ?, ?, ?)",
+            (session_id, cwd, 1706000000000, 1706000005000),
+        )
+
+        user_msg_data = {
+            "role": "user",
+            "model": {"providerID": "openai", "modelID": "gpt-5.3-codex"},
+        }
+        assistant_msg_data = {
+            "role": "assistant",
+            "model": {"providerID": "openai", "modelID": "gpt-5.3-codex"},
+            "tokens": {
+                "input": 120,
+                "output": 40,
+                "reasoning": 10,
+                "cache": {"read": 30, "write": 0},
+            },
+        }
+        conn.execute(
+            "INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)",
+            ("msg_1", session_id, 1706000001000, json.dumps(user_msg_data)),
+        )
+        conn.execute(
+            "INSERT INTO message (id, session_id, time_created, data) VALUES (?, ?, ?, ?)",
+            ("msg_2", session_id, 1706000002000, json.dumps(assistant_msg_data)),
+        )
+
+        conn.execute(
+            "INSERT INTO part (id, message_id, time_created, data) VALUES (?, ?, ?, ?)",
+            ("prt_1", "msg_1", 1706000001001, json.dumps({"type": "text", "text": "please list files"})),
+        )
+        conn.execute(
+            "INSERT INTO part (id, message_id, time_created, data) VALUES (?, ?, ?, ?)",
+            ("prt_2", "msg_2", 1706000002001, json.dumps({"type": "reasoning", "text": "Thinking..."})),
+        )
+        conn.execute(
+            "INSERT INTO part (id, message_id, time_created, data) VALUES (?, ?, ?, ?)",
+            (
+                "prt_3",
+                "msg_2",
+                1706000002002,
+                json.dumps(
+                    {
+                        "type": "tool",
+                        "tool": "bash",
+                        "state": {"status": "completed", "input": {"command": "ls -la"}},
+                    }
+                ),
+            ),
+        )
+        conn.execute(
+            "INSERT INTO part (id, message_id, time_created, data) VALUES (?, ?, ?, ?)",
+            (
+                "prt_4",
+                "msg_2",
+                1706000002003,
+                json.dumps({"type": "text", "text": "I checked the directory."}),
+            ),
+        )
+        conn.commit()
+        conn.close()
+
+        monkeypatch.setattr("dataclaw.parser.OPENCODE_DB_PATH", db_path)
+        monkeypatch.setattr("dataclaw.parser._OPENCODE_PROJECT_INDEX", {})
+
+        sessions = parse_project_sessions(cwd, mock_anonymizer, source="opencode")
+        assert len(sessions) == 1
+        assert sessions[0]["project"] == "opencode:repo"
+        assert sessions[0]["model"] == "openai/gpt-5.3-codex"
+        assert sessions[0]["stats"]["input_tokens"] == 150
+        assert sessions[0]["stats"]["output_tokens"] == 40
+        assert sessions[0]["messages"][0]["role"] == "user"
+        assert sessions[0]["messages"][1]["role"] == "assistant"
+        assert sessions[0]["messages"][1]["tool_uses"][0]["tool"] == "bash"
+
 
 # --- Subagent-only session discovery and parsing ---
 
@@ -808,6 +945,9 @@ class TestDiscoverSubagentProjects:
         monkeypatch.setattr("dataclaw.parser.CODEX_SESSIONS_DIR", tmp_path / "no-codex-sessions")
         monkeypatch.setattr("dataclaw.parser.CODEX_ARCHIVED_DIR", tmp_path / "no-codex-archived")
         monkeypatch.setattr("dataclaw.parser._CODEX_PROJECT_INDEX", {})
+        monkeypatch.setattr("dataclaw.parser.GEMINI_DIR", tmp_path / "no-gemini")
+        monkeypatch.setattr("dataclaw.parser.OPENCODE_DB_PATH", tmp_path / "no-opencode.db")
+        monkeypatch.setattr("dataclaw.parser._OPENCODE_PROJECT_INDEX", {})
 
     def test_discover_includes_subagent_sessions(self, tmp_path, monkeypatch, mock_anonymizer):
         self._disable_codex(tmp_path, monkeypatch)


### PR DESCRIPTION
## Summary

- Adds OpenCode as a source, parsing its SQLite database (`~/.local/share/opencode/opencode.db`)
- Discovers sessions, extracts messages/parts with model info, token stats, and tool calls
- Updates CLI source options to include `opencode`
- All 258 tests pass

Based on PR #9 by @KNN-07, with conflict resolution against Gemini (#8) and subagent (#6) support.

## Test plan

- [x] All 258 tests pass (including 2 new OpenCode-specific tests)
- [x] Conflict resolution verified against current main

🤖 Generated with [Claude Code](https://claude.com/claude-code)