### PR TITLE
Parallelize the work

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ Step 2 (INSTALL SKILL) is omitted in manual usage.
 | `dataclaw diff-jsonl --old old.jsonl --new new.jsonl` | Structurally diff two export JSONL files and write YAML |
 | `dataclaw update-skill claude` | Install/update the dataclaw skill for Claude Code |
 
+Set `DATACLAW_WORKERS` to control the worker count used by parallel operations such as `export`, `confirm`, and `diff-jsonl`.
+
 ## What gets exported
 
 - User messages - Including voice transcripts and images

--- a/dataclaw/_cli/exporting.py
+++ b/dataclaw/_cli/exporting.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 from .. import _json as json
+from .._workers import configured_workers
 from ..anonymizer import Anonymizer
 from ..parser import iter_project_sessions
 from ..secrets import redact_session
@@ -163,12 +164,8 @@ def _resolve_export_workers(task_count: int, workers: int | None = None) -> int:
     if task_count < 2:
         return 1
 
-    raw = os.environ.get("DATACLAW_EXPORT_WORKERS")
-    if workers is None and raw:
-        try:
-            workers = int(raw)
-        except ValueError:
-            workers = None
+    if workers is None:
+        workers = configured_workers()
 
     if workers is None:
         workers = os.cpu_count() or 1

--- a/dataclaw/_cli/exporting.py
+++ b/dataclaw/_cli/exporting.py
@@ -1,12 +1,13 @@
 """Export and publish helpers for the DataClaw CLI."""
 
 import hashlib
+import heapq
 import os
 import sys
 import time
 import urllib.error
 import urllib.request
-from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import FIRST_COMPLETED, ProcessPoolExecutor, wait
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -217,11 +218,10 @@ def _export_session_task_worker(payload) -> _WorkerSessionResult:
 
 
 def _build_project_state(selected_projects: list[dict]) -> list[dict[str, Any]]:
-    start_time = time.perf_counter()
     return [
         {
             "display_name": project["display_name"],
-            "start_time": start_time,
+            "start_time": None,
             "remaining": 0,
             "sessions": 0,
             "input_tokens": 0,
@@ -234,7 +234,9 @@ def _build_project_state(selected_projects: list[dict]) -> list[dict[str, Any]]:
 
 
 def _print_project_summary(state: dict[str, Any]) -> None:
-    elapsed = time.perf_counter() - state["start_time"]
+    start_time = state["start_time"]
+    end_time = time.perf_counter()
+    elapsed = 0.0 if start_time is None else end_time - start_time
     token_summary = ""
     if state["has_token_stats"]:
         token_summary = (
@@ -358,24 +360,52 @@ def _export_to_jsonl_parallel(
     seen_fingerprints: set[str] = set()
     project_state = _build_project_state(selected_projects)
 
-    for task in tasks:
+    ordered_tasks = sorted(tasks, key=lambda task: (task.project_index, task.task_index))
+    completed: dict[int, _WorkerSessionResult] = {}
+    pending: dict[object, int] = {}
+    candidate_heap: list[tuple[int, int]] = []
+    next_write_index = 0
+    frontier_limit = 0
+    max_pending = workers
+    reorder_window = workers * 2
+
+    for task in ordered_tasks:
         project_state[task.project_index]["remaining"] += 1
 
-    ordered_tasks = sorted(tasks, key=lambda task: (-task.estimated_bytes, task.project_index, task.task_index))
     extra_usernames = _export_extra_usernames(anonymizer)
-    payloads = [(task, include_thinking, custom_strings, extra_usernames) for task in ordered_tasks]
 
-    with ProcessPoolExecutor(max_workers=workers) as executor:
-        for result in executor.map(_export_session_task_worker, payloads, chunksize=1):
-            state = project_state[result.project_index]
+    def extend_frontier() -> None:
+        nonlocal frontier_limit
+        target_limit = min(len(ordered_tasks), next_write_index + reorder_window)
+        while frontier_limit < target_limit:
+            task = ordered_tasks[frontier_limit]
+            heapq.heappush(candidate_heap, (-task.estimated_bytes, frontier_limit))
+            frontier_limit += 1
+
+    def submit_ready(executor: ProcessPoolExecutor) -> None:
+        while len(pending) < max_pending and candidate_heap:
+            _neg_size, order_index = heapq.heappop(candidate_heap)
+            task = ordered_tasks[order_index]
+            state = project_state[task.project_index]
+            if state["start_time"] is None:
+                state["start_time"] = time.perf_counter()
+            payload = (task, include_thinking, custom_strings, extra_usernames)
+            future = executor.submit(_export_session_task_worker, payload)
+            pending[future] = order_index
+
+    def flush_ready_results() -> None:
+        nonlocal next_write_index, total, skipped, total_redactions, total_input_tokens, total_output_tokens
+
+        while next_write_index in completed:
+            result = completed.pop(next_write_index)
+            task = ordered_tasks[next_write_index]
+            state = project_state[task.project_index]
             state["remaining"] -= 1
 
             if result.skipped_model:
                 skipped += 1
             elif result.row_bytes is not None:
-                if result.fingerprint is not None and result.fingerprint in seen_fingerprints:
-                    pass
-                else:
+                if result.fingerprint is None or result.fingerprint not in seen_fingerprints:
                     if result.fingerprint is not None:
                         seen_fingerprints.add(result.fingerprint)
                     fh.write(result.row_bytes)
@@ -404,6 +434,30 @@ def _export_to_jsonl_parallel(
             if state["remaining"] == 0 and not state["printed"]:
                 state["printed"] = True
                 _print_project_summary(state)
+
+            next_write_index += 1
+
+    with ProcessPoolExecutor(max_workers=workers) as executor:
+        extend_frontier()
+        submit_ready(executor)
+
+        while pending or candidate_heap or frontier_limit < len(ordered_tasks):
+            if not pending:
+                extend_frontier()
+                submit_ready(executor)
+                if not pending:
+                    break
+
+            done, _ = wait(tuple(pending), return_when=FIRST_COMPLETED)
+            for future in done:
+                order_index = pending.pop(future)
+                completed[order_index] = future.result()
+
+            flush_ready_results()
+            extend_frontier()
+            submit_ready(executor)
+
+    flush_ready_results()
 
     return {
         "sessions": total,

--- a/dataclaw/_cli/exporting.py
+++ b/dataclaw/_cli/exporting.py
@@ -1,17 +1,22 @@
 """Export and publish helpers for the DataClaw CLI."""
 
 import hashlib
+import os
 import sys
 import time
 import urllib.error
 import urllib.request
+from concurrent.futures import ProcessPoolExecutor
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 from .. import _json as json
 from ..anonymizer import Anonymizer
+from ..parser import iter_project_sessions
 from ..secrets import redact_session
+from ..session_tasks import ExportSessionTask, build_export_session_tasks, parse_export_session_task
 from .common import HF_TAG, REPO_URL, SKILL_URL, _format_token_count, _provider_dataset_tags
 
 
@@ -133,14 +138,122 @@ def _gemini_dedupe_fingerprint(session: dict, source: str) -> str | None:
     return hasher.hexdigest()
 
 
-def export_to_jsonl(
+@dataclass(frozen=True, slots=True)
+class _WorkerSessionResult:
+    project_index: int
+    model: str | None = None
+    row_bytes: bytes | None = None
+    fingerprint: str | None = None
+    redactions: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    has_token_stats: bool = False
+    skipped_model: bool = False
+
+
+def _export_extra_usernames(anonymizer: Anonymizer) -> tuple[str, ...]:
+    extra = getattr(anonymizer, "_extra_dict", {})
+    if isinstance(extra, dict):
+        return tuple(sorted(extra.keys()))
+    return ()
+
+
+def _resolve_export_workers(task_count: int, workers: int | None = None) -> int:
+    if task_count < 2:
+        return 1
+
+    raw = os.environ.get("DATACLAW_EXPORT_WORKERS")
+    if workers is None and raw:
+        try:
+            workers = int(raw)
+        except ValueError:
+            workers = None
+
+    if workers is None:
+        workers = os.cpu_count() or 1
+
+    return max(1, min(workers, task_count))
+
+
+def _can_parallelize_export(parse_project_sessions_fn, task_count: int, workers: int) -> bool:
+    return parse_project_sessions_fn is iter_project_sessions and task_count > 1 and workers > 1
+
+
+def _export_session_task_worker(payload) -> _WorkerSessionResult:
+    task, include_thinking, custom_strings, extra_usernames = payload
+    anonymizer = Anonymizer(extra_usernames=list(extra_usernames))
+    try:
+        session = parse_export_session_task(task, anonymizer, include_thinking)
+    except OSError:
+        return _WorkerSessionResult(project_index=task.project_index)
+
+    if not session or not session.get("messages"):
+        return _WorkerSessionResult(project_index=task.project_index)
+
+    session["project"] = task.project_display_name
+    session["source"] = task.source
+    if task.default_model and not session.get("model"):
+        session["model"] = task.default_model
+
+    model = session.get("model")
+    if not model or model == "<synthetic>":
+        return _WorkerSessionResult(project_index=task.project_index, skipped_model=True)
+
+    fingerprint = _gemini_dedupe_fingerprint(session, task.source)
+    session, n_redacted = redact_session(session, custom_strings=custom_strings)
+    stats = session.get("stats", {})
+    input_tokens, output_tokens = _token_totals(stats)
+    has_token_stats = isinstance(stats, dict) and ("input_tokens" in stats or "output_tokens" in stats)
+    return _WorkerSessionResult(
+        project_index=task.project_index,
+        model=model,
+        row_bytes=json.dumps_bytes(session),
+        fingerprint=fingerprint,
+        redactions=n_redacted,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        has_token_stats=has_token_stats,
+    )
+
+
+def _build_project_state(selected_projects: list[dict]) -> list[dict[str, Any]]:
+    start_time = time.perf_counter()
+    return [
+        {
+            "display_name": project["display_name"],
+            "start_time": start_time,
+            "remaining": 0,
+            "sessions": 0,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "has_token_stats": False,
+            "printed": False,
+        }
+        for project in selected_projects
+    ]
+
+
+def _print_project_summary(state: dict[str, Any]) -> None:
+    elapsed = time.perf_counter() - state["start_time"]
+    token_summary = ""
+    if state["has_token_stats"]:
+        token_summary = (
+            f" ({_format_token_count(state['input_tokens'])} input / "
+            f"{_format_token_count(state['output_tokens'])} output tokens)"
+        )
+    print(
+        f"  Parsing {state['display_name']}... {state['sessions']} sessions in {_format_elapsed_seconds(elapsed)}{token_summary}"
+    )
+
+
+def _export_to_jsonl_serial(
     selected_projects: list[dict],
-    output_path: Path,
+    fh,
     anonymizer: Anonymizer,
     parse_project_sessions_fn,
     default_source: str,
-    include_thinking: bool = True,
-    custom_strings: list[str] | None = None,
+    include_thinking: bool,
+    custom_strings: list[str] | None,
 ) -> dict:
     total = 0
     skipped = 0
@@ -151,75 +264,68 @@ def export_to_jsonl(
     total_output_tokens = 0
     seen_fingerprints: set[str] = set()
 
-    try:
-        fh = open(output_path, "wb")
-    except OSError as e:
-        print(f"Error: cannot write to {output_path}: {e}", file=sys.stderr)
-        sys.exit(1)
+    for project in selected_projects:
+        print(f"  Parsing {project['display_name']}...", end="", flush=True)
+        project_start_time = time.perf_counter()
+        sessions = parse_project_sessions_fn(
+            project["dir_name"],
+            anonymizer=anonymizer,
+            include_thinking=include_thinking,
+            source=project.get("source", default_source),
+        )
+        proj_count = 0
+        project_input_tokens = 0
+        project_output_tokens = 0
+        project_has_token_stats = False
+        for session in sessions:
+            source = session.get("source") or project.get("source", default_source)
+            model = session.get("model")
+            if not model or model == "<synthetic>":
+                skipped += 1
+                continue
 
-    with fh as f:
-        for project in selected_projects:
-            print(f"  Parsing {project['display_name']}...", end="", flush=True)
-            project_start_time = time.perf_counter()
-            sessions = parse_project_sessions_fn(
-                project["dir_name"],
-                anonymizer=anonymizer,
-                include_thinking=include_thinking,
-                source=project.get("source", default_source),
+            fingerprint = _gemini_dedupe_fingerprint(session, source)
+            if fingerprint is not None and fingerprint in seen_fingerprints:
+                continue
+
+            session, n_redacted = redact_session(session, custom_strings=custom_strings)
+            total_redactions += n_redacted
+
+            if fingerprint is not None:
+                seen_fingerprints.add(fingerprint)
+
+            fh.write(json.dumps_bytes(session))
+            fh.write(b"\n")
+            total += 1
+            proj_count += 1
+            stats = session.get("stats", {})
+            input_tokens, output_tokens = _token_totals(stats)
+            if isinstance(stats, dict) and ("input_tokens" in stats or "output_tokens" in stats):
+                project_has_token_stats = True
+            project_input_tokens += input_tokens
+            project_output_tokens += output_tokens
+            total_input_tokens += input_tokens
+            total_output_tokens += output_tokens
+            _add_breakdown_row(
+                model_breakdown,
+                _normalize_model_stats_key(model),
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
             )
-            proj_count = 0
-            project_input_tokens = 0
-            project_output_tokens = 0
-            project_has_token_stats = False
-            for session in sessions:
-                source = session.get("source") or project.get("source", default_source)
-                model = session.get("model")
-                if not model or model == "<synthetic>":
-                    skipped += 1
-                    continue
-
-                fingerprint = _gemini_dedupe_fingerprint(session, source)
-                if fingerprint is not None and fingerprint in seen_fingerprints:
-                    continue
-
-                session, n_redacted = redact_session(session, custom_strings=custom_strings)
-                total_redactions += n_redacted
-
-                if fingerprint is not None:
-                    seen_fingerprints.add(fingerprint)
-
-                f.write(json.dumps_bytes(session))
-                f.write(b"\n")
-                total += 1
-                proj_count += 1
-                stats = session.get("stats", {})
-                input_tokens, output_tokens = _token_totals(stats)
-                if isinstance(stats, dict) and ("input_tokens" in stats or "output_tokens" in stats):
-                    project_has_token_stats = True
-                project_input_tokens += input_tokens
-                project_output_tokens += output_tokens
-                total_input_tokens += input_tokens
-                total_output_tokens += output_tokens
-                _add_breakdown_row(
-                    model_breakdown,
-                    _normalize_model_stats_key(model),
-                    input_tokens=input_tokens,
-                    output_tokens=output_tokens,
-                )
-                _add_breakdown_row(
-                    project_breakdown,
-                    _normalize_project_stats_key(session.get("project") or project["display_name"]),
-                    input_tokens=input_tokens,
-                    output_tokens=output_tokens,
-                )
-            project_elapsed = time.perf_counter() - project_start_time
-            token_summary = ""
-            if project_has_token_stats:
-                token_summary = (
-                    f" ({_format_token_count(project_input_tokens)} input / "
-                    f"{_format_token_count(project_output_tokens)} output tokens)"
-                )
-            print(f" {proj_count} sessions in {_format_elapsed_seconds(project_elapsed)}{token_summary}")
+            _add_breakdown_row(
+                project_breakdown,
+                _normalize_project_stats_key(session.get("project") or project["display_name"]),
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+            )
+        project_elapsed = time.perf_counter() - project_start_time
+        token_summary = ""
+        if project_has_token_stats:
+            token_summary = (
+                f" ({_format_token_count(project_input_tokens)} input / "
+                f"{_format_token_count(project_output_tokens)} output tokens)"
+            )
+        print(f" {proj_count} sessions in {_format_elapsed_seconds(project_elapsed)}{token_summary}")
 
     return {
         "sessions": total,
@@ -231,6 +337,125 @@ def export_to_jsonl(
         "total_output_tokens": total_output_tokens,
         "exported_at": datetime.now(tz=timezone.utc).isoformat(),
     }
+
+
+def _export_to_jsonl_parallel(
+    selected_projects: list[dict],
+    fh,
+    include_thinking: bool,
+    custom_strings: list[str] | None,
+    tasks: list[ExportSessionTask],
+    workers: int,
+    anonymizer: Anonymizer,
+) -> dict:
+    total = 0
+    skipped = 0
+    total_redactions = 0
+    model_breakdown: dict[str, dict[str, int]] = {}
+    project_breakdown: dict[str, dict[str, int]] = {}
+    total_input_tokens = 0
+    total_output_tokens = 0
+    seen_fingerprints: set[str] = set()
+    project_state = _build_project_state(selected_projects)
+
+    for task in tasks:
+        project_state[task.project_index]["remaining"] += 1
+
+    ordered_tasks = sorted(tasks, key=lambda task: (-task.estimated_bytes, task.project_index, task.task_index))
+    extra_usernames = _export_extra_usernames(anonymizer)
+    payloads = [(task, include_thinking, custom_strings, extra_usernames) for task in ordered_tasks]
+
+    with ProcessPoolExecutor(max_workers=workers) as executor:
+        for result in executor.map(_export_session_task_worker, payloads, chunksize=1):
+            state = project_state[result.project_index]
+            state["remaining"] -= 1
+
+            if result.skipped_model:
+                skipped += 1
+            elif result.row_bytes is not None:
+                if result.fingerprint is not None and result.fingerprint in seen_fingerprints:
+                    pass
+                else:
+                    if result.fingerprint is not None:
+                        seen_fingerprints.add(result.fingerprint)
+                    fh.write(result.row_bytes)
+                    fh.write(b"\n")
+                    total += 1
+                    total_redactions += result.redactions
+                    state["sessions"] += 1
+                    state["input_tokens"] += result.input_tokens
+                    state["output_tokens"] += result.output_tokens
+                    state["has_token_stats"] = state["has_token_stats"] or result.has_token_stats
+                    total_input_tokens += result.input_tokens
+                    total_output_tokens += result.output_tokens
+                    _add_breakdown_row(
+                        model_breakdown,
+                        _normalize_model_stats_key(result.model),
+                        input_tokens=result.input_tokens,
+                        output_tokens=result.output_tokens,
+                    )
+                    _add_breakdown_row(
+                        project_breakdown,
+                        _normalize_project_stats_key(state["display_name"]),
+                        input_tokens=result.input_tokens,
+                        output_tokens=result.output_tokens,
+                    )
+
+            if state["remaining"] == 0 and not state["printed"]:
+                state["printed"] = True
+                _print_project_summary(state)
+
+    return {
+        "sessions": total,
+        "skipped": skipped,
+        "redactions": total_redactions,
+        "model_breakdown": model_breakdown,
+        "project_breakdown": project_breakdown,
+        "total_input_tokens": total_input_tokens,
+        "total_output_tokens": total_output_tokens,
+        "exported_at": datetime.now(tz=timezone.utc).isoformat(),
+    }
+
+
+def export_to_jsonl(
+    selected_projects: list[dict],
+    output_path: Path,
+    anonymizer: Anonymizer,
+    parse_project_sessions_fn,
+    default_source: str,
+    include_thinking: bool = True,
+    custom_strings: list[str] | None = None,
+    workers: int | None = None,
+) -> dict:
+    try:
+        fh = open(output_path, "wb")
+    except OSError as e:
+        print(f"Error: cannot write to {output_path}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    with fh as f:
+        if parse_project_sessions_fn is iter_project_sessions:
+            tasks = build_export_session_tasks(selected_projects, default_source)
+            resolved_workers = _resolve_export_workers(len(tasks), workers)
+            if _can_parallelize_export(parse_project_sessions_fn, len(tasks), resolved_workers):
+                return _export_to_jsonl_parallel(
+                    selected_projects,
+                    f,
+                    include_thinking,
+                    custom_strings,
+                    tasks,
+                    resolved_workers,
+                    anonymizer,
+                )
+        return _export_to_jsonl_serial(
+            selected_projects,
+            f,
+            anonymizer,
+            parse_project_sessions_fn,
+            default_source,
+            include_thinking,
+            custom_strings,
+        )
 
 
 def summarize_export_jsonl(jsonl_path: Path) -> dict:

--- a/dataclaw/_cli/review.py
+++ b/dataclaw/_cli/review.py
@@ -1,7 +1,10 @@
 """Review, PII scan, and confirm helpers for the DataClaw CLI."""
 
+import os
 import re
 import sys
+import time
+from concurrent.futures import ProcessPoolExecutor
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -28,6 +31,8 @@ _PII_FALSE_POSITIVE_EMAIL_SUBSTRINGS = frozenset(
     {"noreply", "pytest.fixture", "mcp.tool", "mcp.resource", "server.tool", "tasks.loop", "github.com"}
 )
 _PII_FALSE_POSITIVE_API_KEYS = frozenset({"sk-notification"})
+_REVIEW_MIN_PARALLEL_BYTES = 16 * 1024 * 1024
+_REVIEW_MIN_CHUNK_BYTES = 8 * 1024 * 1024
 
 
 def _find_export_file(file_path: Path | None) -> Path:
@@ -162,8 +167,8 @@ def _scan_pii(file_path: Path) -> dict:
 
     try:
         with open(file_path) as f:
-            for line in f:
-                _update_pii_matches(line, matches_by_scan, high_entropy_matches)
+            for line_no, line in enumerate(f, start=1):
+                _update_pii_matches(line, matches_by_scan, high_entropy_matches, line_no=line_no)
     except OSError:
         return {}
 
@@ -174,13 +179,23 @@ def _update_pii_matches(
     line: str,
     matches_by_scan: dict[str, set[str]],
     high_entropy_matches: dict[str, dict],
+    *,
+    line_no: int | None = None,
 ) -> None:
     for name, pattern in _PII_SCANS.items():
         matches_by_scan[name].update(pattern.findall(line))
 
     for result in _scan_high_entropy_strings(line, max_results=50):
+        if line_no is not None:
+            result = {**result, "_line_no": line_no}
         existing = high_entropy_matches.get(result["match"])
-        if existing is None or result["entropy"] > existing["entropy"]:
+        existing_line = existing.get("_line_no", sys.maxsize) if isinstance(existing, dict) else sys.maxsize
+        result_line = result.get("_line_no", sys.maxsize)
+        if (
+            existing is None
+            or result["entropy"] > existing["entropy"]
+            or (result["entropy"] == existing["entropy"] and result_line < existing_line)
+        ):
             high_entropy_matches[result["match"]] = result
 
 
@@ -196,9 +211,14 @@ def _finalize_pii_results(matches_by_scan: dict[str, set[str]], high_entropy_mat
         if matches:
             results[name] = sorted(matches)[:20]
 
-    high_entropy = sorted(high_entropy_matches.values(), key=lambda result: result["entropy"], reverse=True)[:15]
+    high_entropy = sorted(
+        high_entropy_matches.values(),
+        key=lambda result: (-result["entropy"], result.get("_line_no", sys.maxsize)),
+    )[:15]
     if high_entropy:
-        results["high_entropy_strings"] = high_entropy
+        results["high_entropy_strings"] = [
+            {key: value for key, value in result.items() if key != "_line_no"} for result in high_entropy
+        ]
 
     return results
 
@@ -226,7 +246,166 @@ def _record_text_occurrence(
     return 1
 
 
-def _scan_export_review(file_path: Path, full_name_query: str | None = None, max_examples: int = 5) -> dict:
+def _resolve_review_workers(file_size: int, workers: int | None = None) -> int:
+    if workers is not None:
+        return max(1, workers)
+
+    if file_size < _REVIEW_MIN_PARALLEL_BYTES:
+        return 1
+
+    raw = os.environ.get("DATACLAW_CONFIRM_WORKERS")
+    if raw:
+        try:
+            workers = int(raw)
+        except ValueError:
+            workers = None
+
+    if workers is None:
+        workers = os.cpu_count() or 1
+
+    max_by_size = max(1, (file_size + _REVIEW_MIN_CHUNK_BYTES - 1) // _REVIEW_MIN_CHUNK_BYTES)
+    return max(1, min(workers, max_by_size))
+
+
+def _plan_review_chunks(file_path: Path, workers: int) -> list[tuple[int, int, int]]:
+    file_size = file_path.stat().st_size
+    if file_size <= 0 or workers <= 1:
+        return [(0, file_size, 1)]
+
+    target_bytes = max(file_size // workers, 1)
+    chunks: list[tuple[int, int, int]] = []
+    start_offset = 0
+    start_line = 1
+    offset = 0
+    line_no = 1
+    chunk_bytes = 0
+
+    with file_path.open("rb") as handle:
+        while block := handle.read(1024 * 1024):
+            for byte in block:
+                offset += 1
+                chunk_bytes += 1
+                if byte != 0x0A:
+                    continue
+                line_no += 1
+                if chunk_bytes >= target_bytes and len(chunks) < workers - 1:
+                    chunks.append((start_offset, offset, start_line))
+                    start_offset = offset
+                    start_line = line_no
+                    chunk_bytes = 0
+
+    if start_offset < offset or not chunks:
+        chunks.append((start_offset, offset, start_line))
+    return chunks
+
+
+def _scan_review_chunk(payload: tuple[str, int, int, int, str | None, int]) -> dict:
+    file_path_str, start_offset, end_offset, start_line, full_name_query, max_examples = payload
+    full_name_pattern = re.compile(re.escape(full_name_query), re.IGNORECASE) if full_name_query else None
+    matches_by_scan: dict[str, set[str]] = {name: set() for name in _PII_SCANS}
+    high_entropy_matches: dict[str, dict] = {}
+    full_name_matches = 0
+    full_name_examples: list[dict[str, object]] = []
+    projects: dict[str, int] = {}
+    models: dict[str, int] = {}
+    total = 0
+
+    with open(file_path_str, "rb") as handle:
+        handle.seek(start_offset)
+        line_no = start_line
+        while handle.tell() < end_offset:
+            raw_line = handle.readline()
+            if not raw_line:
+                break
+            line = raw_line.decode("utf-8").replace("\r\n", "\n").replace("\r", "\n")
+
+            if full_name_pattern is not None:
+                full_name_matches += _record_text_occurrence(
+                    line_no,
+                    line,
+                    full_name_pattern,
+                    full_name_examples,
+                    max_examples=max_examples,
+                )
+
+            _update_pii_matches(line, matches_by_scan, high_entropy_matches, line_no=line_no)
+
+            stripped = line.strip()
+            if stripped:
+                row = json.loads(stripped)
+                total += 1
+                project = row.get("project", "<unknown>")
+                projects[project] = projects.get(project, 0) + 1
+                model = row.get("model", "<unknown>")
+                models[model] = models.get(model, 0) + 1
+
+            line_no += 1
+
+    return {
+        "total_sessions": total,
+        "projects": projects,
+        "models": models,
+        "matches_by_scan": matches_by_scan,
+        "high_entropy_matches": high_entropy_matches,
+        "full_name_matches": full_name_matches,
+        "full_name_examples": full_name_examples,
+    }
+
+
+def _merge_review_chunk_results(
+    results: list[dict],
+    full_name_query: str | None = None,
+    max_examples: int = 5,
+) -> dict:
+    matches_by_scan: dict[str, set[str]] = {name: set() for name in _PII_SCANS}
+    high_entropy_matches: dict[str, dict] = {}
+    full_name_matches = 0
+    full_name_examples: list[dict[str, object]] = []
+    projects: dict[str, int] = {}
+    models: dict[str, int] = {}
+    total = 0
+
+    for result in results:
+        total += result["total_sessions"]
+        full_name_matches += result["full_name_matches"]
+        full_name_examples.extend(result["full_name_examples"])
+
+        for name, matches in result["matches_by_scan"].items():
+            matches_by_scan[name].update(matches)
+
+        for token, candidate in result["high_entropy_matches"].items():
+            existing = high_entropy_matches.get(token)
+            existing_line = existing.get("_line_no", sys.maxsize) if isinstance(existing, dict) else sys.maxsize
+            candidate_line = candidate.get("_line_no", sys.maxsize)
+            if (
+                existing is None
+                or candidate["entropy"] > existing["entropy"]
+                or (candidate["entropy"] == existing["entropy"] and candidate_line < existing_line)
+            ):
+                high_entropy_matches[token] = candidate
+
+        for project, count in result["projects"].items():
+            projects[project] = projects.get(project, 0) + count
+        for model, count in result["models"].items():
+            models[model] = models.get(model, 0) + count
+
+    merged = {
+        "total_sessions": total,
+        "projects": projects,
+        "models": models,
+        "pii_scan": _finalize_pii_results(matches_by_scan, high_entropy_matches),
+    }
+    if full_name_query is not None:
+        full_name_examples.sort(key=lambda example: example["line"])
+        merged["full_name_scan"] = {
+            "query": full_name_query,
+            "match_count": full_name_matches,
+            "examples": full_name_examples[:max_examples],
+        }
+    return merged
+
+
+def _scan_export_review_serial(file_path: Path, full_name_query: str | None = None, max_examples: int = 5) -> dict:
     full_name_pattern = None
     if full_name_query:
         full_name_pattern = re.compile(re.escape(full_name_query), re.IGNORECASE)
@@ -250,7 +429,7 @@ def _scan_export_review(file_path: Path, full_name_query: str | None = None, max
                     max_examples=max_examples,
                 )
 
-            _update_pii_matches(line, matches_by_scan, high_entropy_matches)
+            _update_pii_matches(line, matches_by_scan, high_entropy_matches, line_no=line_no)
 
             line = line.strip()
             if not line:
@@ -276,6 +455,24 @@ def _scan_export_review(file_path: Path, full_name_query: str | None = None, max
             "examples": full_name_examples,
         }
     return result
+
+
+def _scan_export_review(
+    file_path: Path, full_name_query: str | None = None, max_examples: int = 5, workers: int | None = None
+) -> dict:
+    resolved_workers = _resolve_review_workers(file_path.stat().st_size, workers)
+    if resolved_workers <= 1:
+        return _scan_export_review_serial(file_path, full_name_query, max_examples)
+
+    chunks = _plan_review_chunks(file_path, resolved_workers)
+    payloads = [
+        (str(file_path), start_offset, end_offset, start_line, full_name_query, max_examples)
+        for start_offset, end_offset, start_line in chunks
+    ]
+
+    with ProcessPoolExecutor(max_workers=resolved_workers) as executor:
+        results = list(executor.map(_scan_review_chunk, payloads, chunksize=1))
+    return _merge_review_chunk_results(results, full_name_query, max_examples)
 
 
 def _normalize_attestation_text(value: object) -> str:
@@ -397,6 +594,7 @@ def confirm(
     load_config_fn,
     save_config_fn,
 ) -> None:
+    start_time = time.perf_counter()
     config: DataClawConfig = load_config_fn()
     last_export = config.get("last_export", {})
     file_path = _find_export_file(file_path)
@@ -545,6 +743,7 @@ def confirm(
         "stage": "confirmed",
         "stage_number": 3,
         "total_stages": 4,
+        "elapsed": f"{time.perf_counter() - start_time:.2f}s",
         "file": str(file_path.resolve()),
         "file_size": _format_size(file_size),
         "total_sessions": total,

--- a/dataclaw/_cli/review.py
+++ b/dataclaw/_cli/review.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from .. import _json as json
+from .._workers import configured_workers
 from ..config import DataClawConfig
 from ..secrets import _has_mixed_char_types, _shannon_entropy
 from .common import (
@@ -253,12 +254,7 @@ def _resolve_review_workers(file_size: int, workers: int | None = None) -> int:
     if file_size < _REVIEW_MIN_PARALLEL_BYTES:
         return 1
 
-    raw = os.environ.get("DATACLAW_CONFIRM_WORKERS")
-    if raw:
-        try:
-            workers = int(raw)
-        except ValueError:
-            workers = None
+    workers = configured_workers()
 
     if workers is None:
         workers = os.cpu_count() or 1

--- a/dataclaw/_workers.py
+++ b/dataclaw/_workers.py
@@ -1,0 +1,18 @@
+"""Shared worker configuration helpers."""
+
+from __future__ import annotations
+
+import os
+
+DATACLAW_WORKERS_ENV = "DATACLAW_WORKERS"
+
+
+def configured_workers() -> int | None:
+    raw = os.environ.get(DATACLAW_WORKERS_ENV)
+    if not raw:
+        return None
+
+    try:
+        return int(raw)
+    except ValueError:
+        return None

--- a/dataclaw/export_tasks.py
+++ b/dataclaw/export_tasks.py
@@ -1,0 +1,19 @@
+"""Shared export task types."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class ExportSessionTask:
+    source: str
+    project_index: int
+    task_index: int
+    project_dir_name: str
+    project_display_name: str
+    estimated_bytes: int
+    kind: str
+    file_path: str | None = None
+    item_id: str | None = None
+    offset: int = 0
+    length: int = 0
+    default_model: str | None = None

--- a/dataclaw/jsonl_tools.py
+++ b/dataclaw/jsonl_tools.py
@@ -18,13 +18,14 @@ from typing import Any
 import orjson
 import yaml
 
-from .secrets import contains_large_binary_value, summarize_large_binary_value
+from .secrets import contains_large_binary_value, should_skip_large_binary_string
 
 IDENTITY_FIELDS = ("source", "project", "session_id", "start_time")
 OMITTED_ORIGINAL_FILE = "<omitted originalFile content>"
 ANSI_RE = re.compile(r"\x1b\[[0-9;]*[a-zA-Z]")
 DEFAULT_YAML_SUFFIX = "_formatted.yaml"
 DEFAULT_DIFF_SUFFIX = "_diff.yaml"
+_LARGE_BLOB_MARKER_RE = re.compile(r"^__DATACLAW_LARGE_BLOB__:(\d+):[0-9a-f]{16}$")
 _YAML_WIDTH = 2147483647
 _BaseDumper = getattr(yaml, "CDumper", yaml.SafeDumper)
 
@@ -44,6 +45,62 @@ Dumper.add_representer(str, _str_representer)
 
 def encode_emojis(text: str) -> str:
     return "".join(f"__EMOJI_{ord(char):x}__" if ord(char) > 0xFFFF else char for char in text)
+
+
+def _large_blob_marker(text: str) -> str:
+    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+    return f"__DATACLAW_LARGE_BLOB__:{len(text)}:{digest}"
+
+
+def _large_blob_summary_from_marker(text: str) -> dict[str, Any] | None:
+    match = _LARGE_BLOB_MARKER_RE.fullmatch(text)
+    if match is None:
+        return None
+    return {"type": "large_blob", "length": int(match.group(1))}
+
+
+def prepare_large_binary_diff_value(value: Any) -> Any:
+    if isinstance(value, str):
+        return _large_blob_marker(value) if should_skip_large_binary_string(value) else value
+    if isinstance(value, dict):
+        return {key: prepare_large_binary_diff_value(child_value) for key, child_value in value.items()}
+    if isinstance(value, list):
+        return [prepare_large_binary_diff_value(item) for item in value]
+    return value
+
+
+def contains_large_binary_marker(value: Any) -> bool:
+    if isinstance(value, str):
+        return _large_blob_summary_from_marker(value) is not None
+    if isinstance(value, dict):
+        return any(contains_large_binary_marker(child_value) for child_value in value.values())
+    if isinstance(value, list):
+        return any(contains_large_binary_marker(item) for item in value)
+    return False
+
+
+def summarize_large_binary_markers(value: Any) -> Any:
+    if isinstance(value, str):
+        summary = _large_blob_summary_from_marker(value)
+        return summary if summary is not None else value
+    if isinstance(value, dict):
+        return {key: summarize_large_binary_markers(child_value) for key, child_value in value.items()}
+    if isinstance(value, list):
+        return [summarize_large_binary_markers(item) for item in value]
+    return value
+
+
+def summarize_large_binary_patch_ops(patch_ops: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    summarized = []
+    for op in patch_ops:
+        had_large_blob_marker = any(
+            contains_large_binary_marker(op.get(field)) for field in ("value", "old", "new") if field in op
+        )
+        summarized_op = summarize_large_binary_markers(op)
+        if summarized_op.get("op") == "replace" and had_large_blob_marker:
+            summarized_op["op"] = "replace_large_blob"
+        summarized.append(summarized_op)
+    return summarized
 
 
 class DecodeStream:
@@ -344,7 +401,7 @@ def build_text_replace_diff(old: str, new: str) -> str | None:
     if old == new or ("\n" not in old and "\n" not in new):
         return None
     diff_lines = list(
-        difflib.unified_diff(old.splitlines(), new.splitlines(), fromfile="old", tofile="new", lineterm="", n=2)
+        difflib.unified_diff(old.splitlines(), new.splitlines(), fromfile="old", tofile="new", lineterm="", n=3)
     )
     if not diff_lines:
         return None
@@ -353,7 +410,9 @@ def build_text_replace_diff(old: str, new: str) -> str | None:
 
 def build_record_patch(old: Any, new: Any) -> list[dict[str, Any]]:
     if contains_large_binary_value(old) or contains_large_binary_value(new):
-        return expand_replace_op("", old, new)
+        return summarize_large_binary_patch_ops(
+            run_jd_patch(prepare_large_binary_diff_value(old), prepare_large_binary_diff_value(new))
+        )
     return run_jd_patch(old, new)
 
 
@@ -362,14 +421,9 @@ def expand_replace_op(path: str, old: Any, new: Any) -> list[dict[str, Any]]:
         return []
 
     if contains_large_binary_value(old) or contains_large_binary_value(new):
-        return [
-            {
-                "op": "replace_large_blob",
-                "path": path,
-                "old": summarize_large_binary_value(old),
-                "new": summarize_large_binary_value(new),
-            }
-        ]
+        return summarize_large_binary_patch_ops(
+            expand_replace_op(path, prepare_large_binary_diff_value(old), prepare_large_binary_diff_value(new))
+        )
 
     if isinstance(old, (dict, list)) and isinstance(new, type(old)):
         nested_patch = run_jd_patch(old, new)

--- a/dataclaw/jsonl_tools.py
+++ b/dataclaw/jsonl_tools.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import difflib
 import hashlib
+import os
 import re
 import shutil
 import subprocess
 import tempfile
 from collections import Counter, deque
 from collections.abc import Callable, Iterable
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -18,6 +20,7 @@ from typing import Any
 import orjson
 import yaml
 
+from ._workers import configured_workers
 from .secrets import contains_large_binary_value, should_skip_large_binary_string
 
 IDENTITY_FIELDS = ("source", "project", "session_id", "start_time")
@@ -155,6 +158,19 @@ def default_diff_output_path(new_path: Path) -> Path:
 
 def _open_text_output(path: Path):
     return path.open("w", encoding="utf-8", newline="\n")
+
+
+def _resolve_diff_workers(task_count: int, workers: int | None = None) -> int:
+    if task_count < 2:
+        return 1
+
+    if workers is None:
+        workers = configured_workers()
+
+    if workers is None:
+        workers = os.cpu_count() or 1
+
+    return max(1, min(workers, task_count))
 
 
 def yaml_dump_documents(documents: Iterable[dict[str, Any]], output_path: Path) -> Path:
@@ -416,6 +432,31 @@ def build_record_patch(old: Any, new: Any) -> list[dict[str, Any]]:
     return run_jd_patch(old, new)
 
 
+def _build_record_patch_worker(payload: tuple[Any, Any]) -> list[dict[str, Any]]:
+    old, new = payload
+    return build_record_patch(old, new)
+
+
+def _resolve_modified_event_patches(
+    modified_events: list[tuple[dict[str, Any], Any, Any]],
+    workers: int | None = None,
+) -> None:
+    if not modified_events:
+        return
+
+    payloads = [(old_obj, new_obj) for _event, old_obj, new_obj in modified_events]
+    resolved_workers = _resolve_diff_workers(len(payloads), workers)
+
+    if resolved_workers <= 1:
+        patches = [_build_record_patch_worker(payload) for payload in payloads]
+    else:
+        with ThreadPoolExecutor(max_workers=resolved_workers) as executor:
+            patches = list(executor.map(_build_record_patch_worker, payloads))
+
+    for (event, _old_obj, _new_obj), patch in zip(modified_events, patches, strict=True):
+        event["patch"] = patch
+
+
 def expand_replace_op(path: str, old: Any, new: Any) -> list[dict[str, Any]]:
     if old == new:
         return []
@@ -492,8 +533,11 @@ def build_events(
     new_records: dict[tuple[Any, ...], dict[str, Any]],
     include_records_for_modified: bool,
     emit_event: Callable[[dict[str, Any]], None],
+    workers: int | None = None,
 ) -> tuple[int, dict[str, int]]:
     event_count = 0
+    events: list[dict[str, Any]] = []
+    modified_events: list[tuple[dict[str, Any], Any, Any]] = []
     summary = {
         "unchanged_records": 0,
         "modified_records": 0,
@@ -524,12 +568,13 @@ def build_events(
                 "identity": identity_dict(key),
                 "old_line": _pop_line_number(old_entry),
                 "new_line": _pop_line_number(new_entry),
-                "patch": build_record_patch(old_entry["obj"], new_entry["obj"]),
+                "patch": [],
             }
             if include_records_for_modified:
                 event["old_record"] = old_entry["obj"]
                 event["new_record"] = new_entry["obj"]
-            emit_event(event)
+            events.append(event)
+            modified_events.append((event, old_entry["obj"], new_entry["obj"]))
             event_count += 1
             summary["modified_records"] += 1
 
@@ -542,7 +587,7 @@ def build_events(
                 continue
             entry = old_records[key][digest]
             lines = _take_line_numbers(entry, count)
-            emit_event(
+            events.append(
                 {
                     "change_type": "removed",
                     "identity": identity_dict(key),
@@ -560,7 +605,7 @@ def build_events(
                 continue
             entry = new_records[key][digest]
             lines = _take_line_numbers(entry, count)
-            emit_event(
+            events.append(
                 {
                     "change_type": "added",
                     "identity": identity_dict(key),
@@ -572,6 +617,11 @@ def build_events(
             event_count += 1
             summary["added_records"] += count
 
+    _resolve_modified_event_patches(modified_events, workers)
+
+    for event in events:
+        emit_event(event)
+
     return event_count, summary
 
 
@@ -581,6 +631,7 @@ def diff_jsonl_files(
     output_path: Path | None = None,
     *,
     include_records_for_modified: bool = False,
+    workers: int | None = None,
 ) -> DiffResult:
     if output_path is None:
         output_path = default_diff_output_path(new_path)
@@ -604,6 +655,7 @@ def diff_jsonl_files(
                 new_records,
                 include_records_for_modified=include_records_for_modified,
                 emit_event=lambda event: _yaml_dump_document(event, events_handle, events_decoded_handle),
+                workers=workers,
             )
 
         summary = {

--- a/dataclaw/jsonl_tools.py
+++ b/dataclaw/jsonl_tools.py
@@ -325,7 +325,7 @@ def join_json_pointer(path_prefix: str, child_path: str) -> str:
     return f"{path_prefix}/{child_path}"
 
 
-def match_key_for_array_item(value: Any) -> tuple[Any, ...] | None:
+def exact_match_key_for_array_item(value: Any) -> tuple[Any, ...] | None:
     if not isinstance(value, dict):
         return None
 
@@ -343,6 +343,65 @@ def match_key_for_array_item(value: Any) -> tuple[Any, ...] | None:
     return None
 
 
+def loose_match_key_for_array_item(value: Any) -> tuple[Any, ...] | None:
+    if not isinstance(value, dict):
+        return None
+
+    if "role" in value and "timestamp" in value:
+        tools = []
+        for tool_use in value.get("tool_uses", []):
+            if isinstance(tool_use, dict):
+                tools.append(tool_use.get("tool"))
+        return (
+            "message",
+            value.get("role"),
+            value.get("timestamp"),
+            tuple(tools),
+            "thinking" in value,
+            "content_parts" in value,
+        )
+
+    if "tool" in value and isinstance(value.get("input"), dict):
+        return ("tool_use", value.get("tool"), tuple(sorted(value.get("input", {}))))
+
+    return None
+
+
+def _pair_array_item_ops(
+    remove_ops: list[dict[str, Any]],
+    add_ops: list[dict[str, Any]],
+    key_fn,
+) -> tuple[list[tuple[dict[str, Any], dict[str, Any]]], list[dict[str, Any]], list[dict[str, Any]]] | None:
+    add_buckets: dict[tuple[Any, ...], deque[dict[str, Any]]] = {}
+    add_keys: list[tuple[Any, ...]] = []
+    for op in add_ops:
+        key = key_fn(op.get("value"))
+        if key is None:
+            return None
+        add_buckets.setdefault(key, deque()).append(op)
+        add_keys.append(key)
+
+    pairs: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    paired_remove_ids: set[int] = set()
+    paired_add_ids: set[int] = set()
+
+    for op in remove_ops:
+        key = key_fn(op.get("value"))
+        if key is None:
+            return None
+        add_queue = add_buckets.get(key)
+        if not add_queue:
+            continue
+        add_op = add_queue.popleft()
+        pairs.append((op, add_op))
+        paired_remove_ids.add(id(op))
+        paired_add_ids.add(id(add_op))
+
+    remaining_removes = [op for op in remove_ops if id(op) not in paired_remove_ids]
+    remaining_adds = [op for op in add_ops if id(op) not in paired_add_ids]
+    return pairs, remaining_removes, remaining_adds
+
+
 def expand_array_item_run(ops: list[dict[str, Any]], path_prefix: str) -> list[dict[str, Any]] | None:
     if not ops:
         return []
@@ -355,31 +414,28 @@ def expand_array_item_run(ops: list[dict[str, Any]], path_prefix: str) -> list[d
     if not removes or not adds:
         return None
 
-    remove_buckets: dict[tuple[Any, ...], list[dict[str, Any]]] = {}
-    add_buckets: dict[tuple[Any, ...], list[dict[str, Any]]] = {}
-    for op in removes:
-        key = match_key_for_array_item(op.get("value"))
-        if key is None:
-            return None
-        remove_buckets.setdefault(key, []).append(op)
-    for op in adds:
-        key = match_key_for_array_item(op.get("value"))
-        if key is None:
-            return None
-        add_buckets.setdefault(key, []).append(op)
-
-    if set(remove_buckets) != set(add_buckets):
+    exact_pairs_result = _pair_array_item_ops(removes, adds, exact_match_key_for_array_item)
+    if exact_pairs_result is None:
         return None
+
+    exact_pairs, remaining_removes, remaining_adds = exact_pairs_result
+    loose_pairs_result = _pair_array_item_ops(remaining_removes, remaining_adds, loose_match_key_for_array_item)
+    if loose_pairs_result is None:
+        return None
+
+    loose_pairs, final_removes, final_adds = loose_pairs_result
 
     expanded: list[dict[str, Any]] = []
     full_path = join_json_pointer(path_prefix, path)
-    for key in sorted(remove_buckets, key=str):
-        remove_items = remove_buckets[key]
-        add_items = add_buckets[key]
-        if len(remove_items) != len(add_items):
-            return None
-        for remove_op, add_op in zip(remove_items, add_items, strict=True):
-            expanded.extend(expand_replace_op(full_path, remove_op.get("value"), add_op.get("value")))
+
+    for remove_op, add_op in [*exact_pairs, *loose_pairs]:
+        expanded.extend(expand_replace_op(full_path, remove_op.get("value"), add_op.get("value")))
+
+    for remove_op in final_removes:
+        expanded.append({"op": "remove", "path": full_path, "value": remove_op.get("value")})
+    for add_op in final_adds:
+        expanded.append({"op": "add", "path": full_path, "value": add_op.get("value")})
+
     return expanded
 
 

--- a/dataclaw/parsers/claude.py
+++ b/dataclaw/parsers/claude.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from ..anonymizer import Anonymizer
+from ..export_tasks import ExportSessionTask
 from ..secrets import should_skip_large_binary_string
 from .common import (
     anonymize_value,
@@ -94,6 +95,60 @@ def parse_project_sessions(
         project_name,
         SOURCE,
     )
+
+
+def build_export_session_tasks(project_index: int, project: dict) -> list[ExportSessionTask]:
+    project_path = PROJECTS_DIR / project["dir_name"]
+    if not project_path.exists():
+        return []
+
+    tasks: list[ExportSessionTask] = []
+    task_index = 0
+    for session_file in sorted(project_path.glob("*.jsonl")):
+        tasks.append(
+            ExportSessionTask(
+                source=SOURCE,
+                project_index=project_index,
+                task_index=task_index,
+                project_dir_name=project["dir_name"],
+                project_display_name=project["display_name"],
+                estimated_bytes=session_file.stat().st_size,
+                kind="claude-root",
+                file_path=str(session_file),
+            )
+        )
+        task_index += 1
+
+    for session_dir in find_subagent_sessions(project_path):
+        subagent_dir = session_dir / "subagents"
+        estimated_bytes = sum(path.stat().st_size for path in subagent_dir.glob("agent-*.jsonl") if path.exists())
+        tasks.append(
+            ExportSessionTask(
+                source=SOURCE,
+                project_index=project_index,
+                task_index=task_index,
+                project_dir_name=project["dir_name"],
+                project_display_name=project["display_name"],
+                estimated_bytes=estimated_bytes,
+                kind="claude-subagent",
+                file_path=str(session_dir),
+            )
+        )
+        task_index += 1
+
+    return tasks
+
+
+def parse_export_session_task(
+    task: ExportSessionTask,
+    anonymizer: Anonymizer,
+    include_thinking: bool,
+) -> dict | None:
+    if task.kind == "claude-root" and task.file_path:
+        return parse_session_file(Path(task.file_path), anonymizer, include_thinking)
+    if task.kind == "claude-subagent" and task.file_path:
+        return parse_subagent_session(Path(task.file_path), anonymizer, include_thinking)
+    return None
 
 
 def build_tool_result_map(entries: Iterable[dict[str, Any]], anonymizer: Anonymizer) -> dict[str, dict]:

--- a/dataclaw/parsers/codex.py
+++ b/dataclaw/parsers/codex.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from .. import _json as json
 from ..anonymizer import Anonymizer
+from ..export_tasks import ExportSessionTask
 from .common import (
     build_prefixed_project_name,
     build_projects_from_index,
@@ -70,6 +71,34 @@ def parse_project_sessions(
         build_project_name(project_dir_name),
         SOURCE,
     )
+
+
+def build_export_session_tasks(project_index: int, project: dict) -> list[ExportSessionTask]:
+    tasks: list[ExportSessionTask] = []
+    for task_index, session_file in enumerate(get_project_index().get(project["dir_name"], [])):
+        tasks.append(
+            ExportSessionTask(
+                source=SOURCE,
+                project_index=project_index,
+                task_index=task_index,
+                project_dir_name=project["dir_name"],
+                project_display_name=project["display_name"],
+                estimated_bytes=session_file.stat().st_size if session_file.exists() else 0,
+                kind="codex",
+                file_path=str(session_file),
+            )
+        )
+    return tasks
+
+
+def parse_export_session_task(
+    task: ExportSessionTask,
+    anonymizer: Anonymizer,
+    include_thinking: bool,
+) -> dict | None:
+    if not task.file_path:
+        return None
+    return parse_session_file(Path(task.file_path), anonymizer, include_thinking, task.project_dir_name)
 
 
 def build_project_index(sessions_dir: Path, archived_dir: Path) -> dict[str, list[Path]]:

--- a/dataclaw/parsers/cursor.py
+++ b/dataclaw/parsers/cursor.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from .. import _json as json
 from ..anonymizer import Anonymizer
+from ..export_tasks import ExportSessionTask
 from ..secrets import redact_text
 from .common import (
     build_prefixed_project_name,
@@ -32,6 +33,7 @@ else:
 UNKNOWN_CURSOR_CWD = "<unknown-cwd>"
 
 _PROJECT_INDEX: dict[str, list[str]] = {}
+_SESSION_SIZE_MAP: dict[str, int] = {}
 
 
 def _try_parse_json(s: Any) -> Any:
@@ -176,6 +178,71 @@ def parse_project_sessions(
             )
     except sqlite3.Error:
         return
+
+
+def build_export_session_tasks(project_index: int, project: dict) -> list[ExportSessionTask]:
+    size_map = build_session_size_map()
+    tasks: list[ExportSessionTask] = []
+    for task_index, composer_id in enumerate(get_project_index().get(project["dir_name"], [])):
+        tasks.append(
+            ExportSessionTask(
+                source=SOURCE,
+                project_index=project_index,
+                task_index=task_index,
+                project_dir_name=project["dir_name"],
+                project_display_name=project["display_name"],
+                estimated_bytes=size_map.get(composer_id, 0),
+                kind="cursor",
+                item_id=composer_id,
+            )
+        )
+    return tasks
+
+
+def parse_export_session_task(
+    task: ExportSessionTask,
+    anonymizer: Anonymizer,
+    include_thinking: bool,
+) -> dict | None:
+    if not task.item_id or not CURSOR_DB.exists():
+        return None
+    try:
+        with sqlite3.connect(f"file:{CURSOR_DB}?mode=ro", uri=True) as conn:
+            return parse_session(task.item_id, conn, anonymizer, include_thinking)
+    except sqlite3.Error:
+        return None
+
+
+def build_session_size_map() -> dict[str, int]:
+    global _SESSION_SIZE_MAP
+    if _SESSION_SIZE_MAP:
+        return _SESSION_SIZE_MAP
+    if not CURSOR_DB.exists():
+        return {}
+
+    sizes: dict[str, int] = {}
+    try:
+        with sqlite3.connect(f"file:{CURSOR_DB}?mode=ro", uri=True) as conn:
+            rows = conn.execute(
+                "SELECT key, LENGTH(value) FROM cursorDiskKV WHERE key LIKE 'composerData:%' OR key LIKE 'bubbleId:%'"
+            )
+            for key, value_len in rows:
+                if not isinstance(key, str):
+                    continue
+                if key.startswith("composerData:"):
+                    composer_id = key.split(":", 1)[1]
+                elif key.startswith("bubbleId:"):
+                    parts = key.split(":", 2)
+                    composer_id = parts[1] if len(parts) >= 3 else ""
+                else:
+                    continue
+                if composer_id:
+                    sizes[composer_id] = sizes.get(composer_id, 0) + int(value_len or 0)
+    except sqlite3.Error:
+        return {}
+
+    _SESSION_SIZE_MAP = sizes
+    return _SESSION_SIZE_MAP
 
 
 def parse_session(

--- a/dataclaw/parsers/custom.py
+++ b/dataclaw/parsers/custom.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from .. import _json as json
 from ..anonymizer import Anonymizer
+from ..export_tasks import ExportSessionTask
 from ..secrets import redact_text
 
 logger = logging.getLogger(__name__)
@@ -60,50 +61,62 @@ def parse_project_sessions(
     if not project_path.exists():
         return
 
-    required_fields = {"session_id", "model", "messages"}
     for jsonl_file in sorted(project_path.glob("*.jsonl")):
         try:
-            for line_num, line in enumerate(jsonl_file.open(), 1):
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    session = json.loads(line)
-                except json.JSONDecodeError:
-                    logger.warning(
-                        "custom:%s: %s line %d: invalid JSON, skipping",
-                        project_dir_name,
-                        jsonl_file.name,
-                        line_num,
-                    )
-                    continue
-                if not isinstance(session, dict):
-                    logger.warning(
-                        "custom:%s: %s line %d: not a JSON object, skipping",
-                        project_dir_name,
-                        jsonl_file.name,
-                        line_num,
-                    )
-                    continue
-                missing = required_fields - session.keys()
-                if missing:
-                    logger.warning(
-                        "custom:%s: %s line %d: missing required fields %s, skipping",
-                        project_dir_name,
-                        jsonl_file.name,
-                        line_num,
-                        sorted(missing),
-                    )
-                    continue
-                session["project"] = f"custom:{project_dir_name}"
-                session["source"] = SOURCE
-                for msg in session.get("messages", []):
-                    if "content" in msg and isinstance(msg["content"], str):
-                        redacted, _ = redact_text(msg["content"])
-                        msg["content"] = anonymizer.text(redacted)
-                yield session
+            for line in jsonl_file.open():
+                session = parse_session_bytes(project_dir_name, line, anonymizer)
+                if session is not None:
+                    yield session
         except OSError:
             logger.warning("custom:%s: failed to read %s", project_dir_name, jsonl_file.name)
+
+
+def build_export_session_tasks(project_index: int, project: dict) -> list[ExportSessionTask]:
+    project_path = CUSTOM_DIR / project["dir_name"]
+    if not project_path.exists():
+        return []
+
+    tasks: list[ExportSessionTask] = []
+    task_index = 0
+    for jsonl_file in sorted(project_path.glob("*.jsonl")):
+        with open(jsonl_file, "rb") as fh:
+            while True:
+                offset = fh.tell()
+                line = fh.readline()
+                if not line:
+                    break
+                if not line.strip():
+                    continue
+                tasks.append(
+                    ExportSessionTask(
+                        source=SOURCE,
+                        project_index=project_index,
+                        task_index=task_index,
+                        project_dir_name=project["dir_name"],
+                        project_display_name=project["display_name"],
+                        estimated_bytes=len(line),
+                        kind="custom-line",
+                        file_path=str(jsonl_file),
+                        offset=offset,
+                        length=len(line),
+                    )
+                )
+                task_index += 1
+    return tasks
+
+
+def parse_export_session_task(
+    task: ExportSessionTask,
+    anonymizer: Anonymizer,
+    include_thinking: bool,
+) -> dict | None:
+    del include_thinking
+    if not task.file_path or task.length <= 0:
+        return None
+    with open(task.file_path, "rb") as fh:
+        fh.seek(task.offset)
+        line = fh.read(task.length)
+    return parse_session_bytes(task.project_dir_name, line, anonymizer)
 
 
 def parse_sessions(project_dir_name: str, custom_dir: Path, anonymizer: Anonymizer) -> list[dict]:
@@ -115,3 +128,34 @@ def parse_sessions(project_dir_name: str, custom_dir: Path, anonymizer: Anonymiz
             custom_dir=custom_dir,
         )
     )
+
+
+def parse_session_bytes(project_dir_name: str, raw_line: bytes | str, anonymizer: Anonymizer) -> dict | None:
+    required_fields = {"session_id", "model", "messages"}
+
+    if isinstance(raw_line, bytes):
+        raw_line = raw_line.decode("utf-8", errors="replace")
+
+    line = raw_line.strip()
+    if not line:
+        return None
+
+    try:
+        session = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+
+    if not isinstance(session, dict):
+        return None
+
+    missing = required_fields - session.keys()
+    if missing:
+        return None
+
+    session["project"] = f"custom:{project_dir_name}"
+    session["source"] = SOURCE
+    for msg in session.get("messages", []):
+        if "content" in msg and isinstance(msg["content"], str):
+            redacted, _ = redact_text(msg["content"])
+            msg["content"] = anonymizer.text(redacted)
+    return session

--- a/dataclaw/parsers/gemini.py
+++ b/dataclaw/parsers/gemini.py
@@ -8,6 +8,7 @@ from typing import Any, Callable
 
 from .. import _json as json
 from ..anonymizer import Anonymizer
+from ..export_tasks import ExportSessionTask
 from ..secrets import should_skip_large_binary_string
 from .common import (
     anonymize_value,
@@ -169,6 +170,38 @@ def parse_project_sessions(
         build_project_name(project_dir_name),
         SOURCE,
     )
+
+
+def build_export_session_tasks(project_index: int, project: dict) -> list[ExportSessionTask]:
+    project_path = GEMINI_DIR / project["dir_name"] / "chats"
+    if not project_path.exists():
+        return []
+
+    tasks: list[ExportSessionTask] = []
+    for task_index, session_file in enumerate(sorted(project_path.glob("session-*.json"))):
+        tasks.append(
+            ExportSessionTask(
+                source=SOURCE,
+                project_index=project_index,
+                task_index=task_index,
+                project_dir_name=project["dir_name"],
+                project_display_name=project["display_name"],
+                estimated_bytes=session_file.stat().st_size if session_file.exists() else 0,
+                kind="gemini",
+                file_path=str(session_file),
+            )
+        )
+    return tasks
+
+
+def parse_export_session_task(
+    task: ExportSessionTask,
+    anonymizer: Anonymizer,
+    include_thinking: bool,
+) -> dict | None:
+    if not task.file_path:
+        return None
+    return parse_session_file(Path(task.file_path), anonymizer, include_thinking)
 
 
 def parse_tool_call(tool_call: dict, anonymizer: Anonymizer) -> dict:

--- a/dataclaw/parsers/kimi.py
+++ b/dataclaw/parsers/kimi.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from .. import _json as json
 from ..anonymizer import Anonymizer
+from ..export_tasks import ExportSessionTask
 from .common import (
     build_prefixed_project_name,
     collect_project_sessions,
@@ -132,6 +133,47 @@ def parse_project_sessions(
         SOURCE,
         default_model="kimi-k2",
     )
+
+
+def build_export_session_tasks(project_index: int, project: dict) -> list[ExportSessionTask]:
+    project_hash = get_project_hash(project["dir_name"])
+    project_path = KIMI_SESSIONS_DIR / project_hash
+    if not project_path.exists():
+        return []
+
+    tasks: list[ExportSessionTask] = []
+    task_index = 0
+    for session_dir in sorted(project_path.iterdir()):
+        if not session_dir.is_dir():
+            continue
+        context_file = session_dir / "context.jsonl"
+        if not context_file.exists():
+            continue
+        tasks.append(
+            ExportSessionTask(
+                source=SOURCE,
+                project_index=project_index,
+                task_index=task_index,
+                project_dir_name=project["dir_name"],
+                project_display_name=project["display_name"],
+                estimated_bytes=context_file.stat().st_size,
+                kind="kimi",
+                file_path=str(context_file),
+                default_model="kimi-k2",
+            )
+        )
+        task_index += 1
+    return tasks
+
+
+def parse_export_session_task(
+    task: ExportSessionTask,
+    anonymizer: Anonymizer,
+    include_thinking: bool,
+) -> dict | None:
+    if not task.file_path:
+        return None
+    return parse_session_file(Path(task.file_path), anonymizer, include_thinking)
 
 
 def parse_session_file(

--- a/dataclaw/parsers/openclaw.py
+++ b/dataclaw/parsers/openclaw.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from .. import _json as json
 from ..anonymizer import Anonymizer
+from ..export_tasks import ExportSessionTask
 from .common import (
     build_prefixed_project_name,
     build_projects_from_index,
@@ -67,6 +68,34 @@ def parse_project_sessions(
         build_project_name(project_dir_name),
         SOURCE,
     )
+
+
+def build_export_session_tasks(project_index: int, project: dict) -> list[ExportSessionTask]:
+    tasks: list[ExportSessionTask] = []
+    for task_index, session_file in enumerate(get_project_index().get(project["dir_name"], [])):
+        tasks.append(
+            ExportSessionTask(
+                source=SOURCE,
+                project_index=project_index,
+                task_index=task_index,
+                project_dir_name=project["dir_name"],
+                project_display_name=project["display_name"],
+                estimated_bytes=session_file.stat().st_size if session_file.exists() else 0,
+                kind="openclaw",
+                file_path=str(session_file),
+            )
+        )
+    return tasks
+
+
+def parse_export_session_task(
+    task: ExportSessionTask,
+    anonymizer: Anonymizer,
+    include_thinking: bool,
+) -> dict | None:
+    if not task.file_path:
+        return None
+    return parse_session_file(Path(task.file_path), anonymizer, include_thinking)
 
 
 def build_project_index(agents_dir: Path) -> dict[str, list[Path]]:

--- a/dataclaw/parsers/opencode.py
+++ b/dataclaw/parsers/opencode.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from ..anonymizer import Anonymizer
+from ..export_tasks import ExportSessionTask
 from .common import (
     build_prefixed_project_name,
     build_projects_from_index,
@@ -27,6 +28,7 @@ OPENCODE_DB_PATH = OPENCODE_DIR / "opencode.db"
 UNKNOWN_OPENCODE_CWD = "<unknown-cwd>"
 
 _PROJECT_INDEX: dict[str, list[str]] = {}
+_SESSION_SIZE_MAP: dict[str, int] = {}
 
 
 def get_project_index(refresh: bool = False) -> dict[str, list[str]]:
@@ -93,6 +95,63 @@ def parse_project_sessions(
             return
 
     return iter_sessions()
+
+
+def build_export_session_tasks(project_index: int, project: dict) -> list[ExportSessionTask]:
+    size_map = build_session_size_map()
+    tasks: list[ExportSessionTask] = []
+    for task_index, session_id in enumerate(get_project_index().get(project["dir_name"], [])):
+        tasks.append(
+            ExportSessionTask(
+                source=SOURCE,
+                project_index=project_index,
+                task_index=task_index,
+                project_dir_name=project["dir_name"],
+                project_display_name=project["display_name"],
+                estimated_bytes=size_map.get(session_id, 0),
+                kind="opencode",
+                item_id=session_id,
+            )
+        )
+    return tasks
+
+
+def parse_export_session_task(
+    task: ExportSessionTask,
+    anonymizer: Anonymizer,
+    include_thinking: bool,
+) -> dict | None:
+    if not task.item_id:
+        return None
+    return parse_session(task.item_id, OPENCODE_DB_PATH, anonymizer, include_thinking, task.project_dir_name)
+
+
+def build_session_size_map() -> dict[str, int]:
+    global _SESSION_SIZE_MAP
+    if _SESSION_SIZE_MAP:
+        return _SESSION_SIZE_MAP
+    if not OPENCODE_DB_PATH.exists():
+        return {}
+
+    query = """
+        WITH message_sizes AS (
+          SELECT session_id, SUM(LENGTH(data)) AS total FROM message GROUP BY session_id
+        ),
+        part_sizes AS (
+          SELECT session_id, SUM(LENGTH(data)) AS total FROM part GROUP BY session_id
+        )
+        SELECT s.id, COALESCE(ms.total, 0) + COALESCE(ps.total, 0)
+        FROM session s
+        LEFT JOIN message_sizes ms ON ms.session_id = s.id
+        LEFT JOIN part_sizes ps ON ps.session_id = s.id
+    """
+
+    try:
+        with sqlite3.connect(OPENCODE_DB_PATH) as conn:
+            _SESSION_SIZE_MAP = {session_id: int(total or 0) for session_id, total in conn.execute(query)}
+            return _SESSION_SIZE_MAP
+    except sqlite3.Error:
+        return {}
 
 
 def build_project_index(db_path: Path) -> dict[str, list[str]]:

--- a/dataclaw/providers.py
+++ b/dataclaw/providers.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
 from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable
+from types import ModuleType
 
 from .anonymizer import Anonymizer
+from .export_tasks import ExportSessionTask
 from .parsers import claude as _claude_mod
 from .parsers import codex as _codex_mod
 from .parsers import cursor as _cursor_mod
@@ -19,8 +22,28 @@ class Provider:
     source: str
     hf_metadata_tag: str
     source_path: Path
-    discover_projects: Callable[[], list[dict]]
-    parse_project_sessions: Callable[[str, Anonymizer, bool], Iterable[dict]]
+
+    def discover_projects(self) -> list[dict]:
+        raise NotImplementedError
+
+    def parse_project_sessions(
+        self,
+        project_dir_name: str,
+        anonymizer: Anonymizer,
+        include_thinking: bool,
+    ) -> Iterable[dict]:
+        raise NotImplementedError
+
+    def build_export_session_tasks(self, project_index: int, project: dict) -> list[ExportSessionTask]:
+        raise NotImplementedError
+
+    def parse_export_session_task(
+        self,
+        task: ExportSessionTask,
+        anonymizer: Anonymizer,
+        include_thinking: bool,
+    ) -> dict | None:
+        raise NotImplementedError
 
     def has_session_source(self) -> bool:
         return self.source_path.exists()
@@ -29,62 +52,82 @@ class Provider:
         return f"{self.source_path} was not found."
 
 
+@dataclass(frozen=True)
+class ModuleProvider(Provider):
+    module: ModuleType
+
+    @classmethod
+    def from_module(cls, module: ModuleType, *, hf_metadata_tag: str, source_path_attr: str) -> ModuleProvider:
+        return cls(
+            source=module.SOURCE,
+            hf_metadata_tag=hf_metadata_tag,
+            source_path=getattr(module, source_path_attr),
+            module=module,
+        )
+
+    def discover_projects(self) -> list[dict]:
+        return self.module.discover_projects()
+
+    def parse_project_sessions(
+        self,
+        project_dir_name: str,
+        anonymizer: Anonymizer,
+        include_thinking: bool,
+    ) -> Iterable[dict]:
+        return self.module.parse_project_sessions(project_dir_name, anonymizer, include_thinking)
+
+    def build_export_session_tasks(self, project_index: int, project: dict) -> list[ExportSessionTask]:
+        return self.module.build_export_session_tasks(project_index, project)
+
+    def parse_export_session_task(
+        self,
+        task: ExportSessionTask,
+        anonymizer: Anonymizer,
+        include_thinking: bool,
+    ) -> dict | None:
+        return self.module.parse_export_session_task(task, anonymizer, include_thinking)
+
+
 PROVIDERS: dict[str, Provider] = {
-    _claude_mod.SOURCE: Provider(
-        source=_claude_mod.SOURCE,
+    _claude_mod.SOURCE: ModuleProvider.from_module(
+        _claude_mod,
         hf_metadata_tag="claude-code",
-        source_path=_claude_mod.CLAUDE_DIR,
-        discover_projects=_claude_mod.discover_projects,
-        parse_project_sessions=_claude_mod.parse_project_sessions,
+        source_path_attr="CLAUDE_DIR",
     ),
-    _codex_mod.SOURCE: Provider(
-        source=_codex_mod.SOURCE,
+    _codex_mod.SOURCE: ModuleProvider.from_module(
+        _codex_mod,
         hf_metadata_tag="codex-cli",
-        source_path=_codex_mod.CODEX_DIR,
-        discover_projects=_codex_mod.discover_projects,
-        parse_project_sessions=_codex_mod.parse_project_sessions,
+        source_path_attr="CODEX_DIR",
     ),
-    _cursor_mod.SOURCE: Provider(
-        source=_cursor_mod.SOURCE,
+    _cursor_mod.SOURCE: ModuleProvider.from_module(
+        _cursor_mod,
         hf_metadata_tag="cursor",
-        source_path=_cursor_mod.CURSOR_DB,
-        discover_projects=_cursor_mod.discover_projects,
-        parse_project_sessions=_cursor_mod.parse_project_sessions,
+        source_path_attr="CURSOR_DB",
     ),
-    _custom_mod.SOURCE: Provider(
-        source=_custom_mod.SOURCE,
+    _custom_mod.SOURCE: ModuleProvider.from_module(
+        _custom_mod,
         hf_metadata_tag="custom",
-        source_path=_custom_mod.CUSTOM_DIR,
-        discover_projects=_custom_mod.discover_projects,
-        parse_project_sessions=_custom_mod.parse_project_sessions,
+        source_path_attr="CUSTOM_DIR",
     ),
-    _gemini_mod.SOURCE: Provider(
-        source=_gemini_mod.SOURCE,
+    _gemini_mod.SOURCE: ModuleProvider.from_module(
+        _gemini_mod,
         hf_metadata_tag="gemini-cli",
-        source_path=_gemini_mod.GEMINI_DIR,
-        discover_projects=_gemini_mod.discover_projects,
-        parse_project_sessions=_gemini_mod.parse_project_sessions,
+        source_path_attr="GEMINI_DIR",
     ),
-    _kimi_mod.SOURCE: Provider(
-        source=_kimi_mod.SOURCE,
+    _kimi_mod.SOURCE: ModuleProvider.from_module(
+        _kimi_mod,
         hf_metadata_tag="kimi-cli",
-        source_path=_kimi_mod.KIMI_DIR,
-        discover_projects=_kimi_mod.discover_projects,
-        parse_project_sessions=_kimi_mod.parse_project_sessions,
+        source_path_attr="KIMI_DIR",
     ),
-    _opencode_mod.SOURCE: Provider(
-        source=_opencode_mod.SOURCE,
+    _opencode_mod.SOURCE: ModuleProvider.from_module(
+        _opencode_mod,
         hf_metadata_tag="opencode",
-        source_path=_opencode_mod.OPENCODE_DIR,
-        discover_projects=_opencode_mod.discover_projects,
-        parse_project_sessions=_opencode_mod.parse_project_sessions,
+        source_path_attr="OPENCODE_DIR",
     ),
-    _openclaw_mod.SOURCE: Provider(
-        source=_openclaw_mod.SOURCE,
+    _openclaw_mod.SOURCE: ModuleProvider.from_module(
+        _openclaw_mod,
         hf_metadata_tag="openclaw",
-        source_path=_openclaw_mod.OPENCLAW_DIR,
-        discover_projects=_openclaw_mod.discover_projects,
-        parse_project_sessions=_openclaw_mod.parse_project_sessions,
+        source_path_attr="OPENCLAW_DIR",
     ),
 }
 

--- a/dataclaw/session_tasks.py
+++ b/dataclaw/session_tasks.py
@@ -1,0 +1,25 @@
+"""Generic export session task orchestration."""
+
+from __future__ import annotations
+
+from .anonymizer import Anonymizer
+from .export_tasks import ExportSessionTask
+from .providers import get_provider
+
+
+def build_export_session_tasks(selected_projects: list[dict], default_source: str) -> list[ExportSessionTask]:
+    tasks: list[ExportSessionTask] = []
+    for project_index, project in enumerate(selected_projects):
+        source = project.get("source", default_source)
+        provider = get_provider(source)
+        tasks.extend(provider.build_export_session_tasks(project_index, project))
+    return tasks
+
+
+def parse_export_session_task(
+    task: ExportSessionTask,
+    anonymizer: Anonymizer,
+    include_thinking: bool,
+) -> dict | None:
+    provider = get_provider(task.source)
+    return provider.parse_export_session_task(task, anonymizer, include_thinking)

--- a/tests/parser_helpers.py
+++ b/tests/parser_helpers.py
@@ -23,6 +23,7 @@ def disable_other_providers(monkeypatch, tmp_path, keep=()):
     if "opencode" not in keep:
         monkeypatch.setattr("dataclaw.parsers.opencode.OPENCODE_DB_PATH", tmp_path / "no-opencode.db")
     monkeypatch.setattr("dataclaw.parsers.opencode._PROJECT_INDEX", {})
+    monkeypatch.setattr("dataclaw.parsers.opencode._SESSION_SIZE_MAP", {})
 
     if "openclaw" not in keep:
         monkeypatch.setattr("dataclaw.parsers.openclaw.OPENCLAW_AGENTS_DIR", tmp_path / "no-openclaw-agents")
@@ -37,6 +38,7 @@ def disable_other_providers(monkeypatch, tmp_path, keep=()):
     if "cursor" not in keep:
         monkeypatch.setattr("dataclaw.parsers.cursor.CURSOR_DB", tmp_path / "no-cursor.vscdb")
     monkeypatch.setattr("dataclaw.parsers.cursor._PROJECT_INDEX", {})
+    monkeypatch.setattr("dataclaw.parsers.cursor._SESSION_SIZE_MAP", {})
 
 
 def write_opencode_db(db_path):

--- a/tests/test_cli_exporting.py
+++ b/tests/test_cli_exporting.py
@@ -1,10 +1,14 @@
 """Tests for CLI export and publish helpers."""
 
+from concurrent.futures import Future
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from dataclaw import _json as json
+from dataclaw import export_tasks
+from dataclaw import parser as parser_mod
+from dataclaw._cli import exporting as exporting_mod
 from dataclaw._cli.exporting import _build_dataset_card, export_to_jsonl, push_to_huggingface, summarize_export_jsonl
 
 
@@ -177,6 +181,157 @@ class TestExportToJsonl:
         )
 
         assert "Parsing test... 1 sessions in 1.25s (12 input / 34 output tokens)" in capsys.readouterr().out
+
+    def test_parallel_export_preserves_serial_order_and_project_summary_order(
+        self, tmp_path, mock_anonymizer, monkeypatch, capsys
+    ):
+        output = tmp_path / "out.jsonl"
+        projects = [
+            {"dir_name": "p1", "display_name": "proj1", "source": "claude"},
+            {"dir_name": "p2", "display_name": "proj2", "source": "claude"},
+        ]
+        tasks = [
+            export_tasks.ExportSessionTask("claude", 0, 0, "p1", "proj1", 10, "fake", item_id="p1-a"),
+            export_tasks.ExportSessionTask("claude", 0, 1, "p1", "proj1", 1, "fake", item_id="p1-b"),
+            export_tasks.ExportSessionTask("claude", 1, 0, "p2", "proj2", 9, "fake", item_id="p2-a"),
+            export_tasks.ExportSessionTask("claude", 1, 1, "p2", "proj2", 2, "fake", item_id="p2-b"),
+        ]
+        completion_order = ["p1-b", "p2-a", "p1-a", "p2-b"]
+
+        class FakeExecutor:
+            def __init__(self, max_workers):
+                self.max_workers = max_workers
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def submit(self, fn, payload):
+                future = Future()
+                future._label = payload[0].item_id
+                future.set_result(fn(payload))
+                return future
+
+        def fake_wait(futures, return_when=None):
+            del return_when
+            futures = set(futures)
+            label = completion_order.pop(0)
+            chosen = next(future for future in futures if getattr(future, "_label", None) == label)
+            return {chosen}, futures - {chosen}
+
+        def fake_worker(payload):
+            task = payload[0]
+            row = {
+                "session_id": task.item_id,
+                "model": f"model-{task.item_id}",
+                "project": task.project_display_name,
+                "messages": [{"role": "user", "content": task.item_id}],
+                "stats": {"input_tokens": 1, "output_tokens": 2},
+            }
+            return exporting_mod._WorkerSessionResult(
+                project_index=task.project_index,
+                model=row["model"],
+                row_bytes=json.dumps_bytes(row),
+                input_tokens=1,
+                output_tokens=2,
+                has_token_stats=True,
+            )
+
+        monkeypatch.setattr("dataclaw._cli.exporting.build_export_session_tasks", lambda *_args, **_kwargs: tasks)
+        monkeypatch.setattr("dataclaw._cli.exporting.ProcessPoolExecutor", FakeExecutor)
+        monkeypatch.setattr("dataclaw._cli.exporting.wait", fake_wait)
+        monkeypatch.setattr("dataclaw._cli.exporting._export_session_task_worker", fake_worker)
+
+        meta = export_to_jsonl(
+            projects,
+            output,
+            mock_anonymizer,
+            parse_project_sessions_fn=parser_mod.iter_project_sessions,
+            default_source="claude",
+            workers=4,
+        )
+
+        rows = [json.loads(line) for line in output.read_bytes().splitlines() if line.strip()]
+        assert [row["session_id"] for row in rows] == ["p1-a", "p1-b", "p2-a", "p2-b"]
+        assert meta["sessions"] == 4
+
+        printed = [line.strip() for line in capsys.readouterr().out.splitlines() if line.strip()]
+        assert printed[0].startswith("Parsing proj1... 2 sessions in ")
+        assert printed[1].startswith("Parsing proj2... 2 sessions in ")
+
+    def test_parallel_gemini_dedupe_respects_serial_order(self, tmp_path, mock_anonymizer, monkeypatch):
+        output = tmp_path / "out.jsonl"
+        projects = [
+            {"dir_name": "upper", "display_name": "gemini:ComfyUI", "source": "gemini"},
+            {"dir_name": "lower", "display_name": "gemini:comfyui", "source": "gemini"},
+        ]
+        tasks = [
+            export_tasks.ExportSessionTask("gemini", 0, 0, "upper", "gemini:ComfyUI", 1, "fake", item_id="first"),
+            export_tasks.ExportSessionTask("gemini", 1, 0, "lower", "gemini:comfyui", 10, "fake", item_id="second"),
+        ]
+        completion_order = ["second", "first"]
+
+        class FakeExecutor:
+            def __init__(self, max_workers):
+                self.max_workers = max_workers
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def submit(self, fn, payload):
+                future = Future()
+                future._label = payload[0].item_id
+                future.set_result(fn(payload))
+                return future
+
+        def fake_wait(futures, return_when=None):
+            del return_when
+            futures = set(futures)
+            label = completion_order.pop(0)
+            chosen = next(future for future in futures if getattr(future, "_label", None) == label)
+            return {chosen}, futures - {chosen}
+
+        def fake_worker(payload):
+            task = payload[0]
+            row = {
+                "session_id": task.item_id,
+                "model": "gemini-2.5-pro",
+                "project": task.project_display_name,
+                "messages": [{"role": "user", "content": "hi"}],
+                "stats": {"input_tokens": 1, "output_tokens": 2},
+            }
+            return exporting_mod._WorkerSessionResult(
+                project_index=task.project_index,
+                model=row["model"],
+                row_bytes=json.dumps_bytes(row),
+                fingerprint="dup",
+                input_tokens=1,
+                output_tokens=2,
+                has_token_stats=True,
+            )
+
+        monkeypatch.setattr("dataclaw._cli.exporting.build_export_session_tasks", lambda *_args, **_kwargs: tasks)
+        monkeypatch.setattr("dataclaw._cli.exporting.ProcessPoolExecutor", FakeExecutor)
+        monkeypatch.setattr("dataclaw._cli.exporting.wait", fake_wait)
+        monkeypatch.setattr("dataclaw._cli.exporting._export_session_task_worker", fake_worker)
+
+        meta = export_to_jsonl(
+            projects,
+            output,
+            mock_anonymizer,
+            parse_project_sessions_fn=parser_mod.iter_project_sessions,
+            default_source="gemini",
+            workers=2,
+        )
+
+        rows = [json.loads(line) for line in output.read_bytes().splitlines() if line.strip()]
+        assert [row["session_id"] for row in rows] == ["first"]
+        assert meta["sessions"] == 1
 
     def test_normalizes_stats_without_changing_dataset_rows(self, tmp_path, mock_anonymizer):
         output = tmp_path / "out.jsonl"

--- a/tests/test_cli_exporting.py
+++ b/tests/test_cli_exporting.py
@@ -73,6 +73,13 @@ class TestBuildDatasetCard:
         card = _build_dataset_card("alice/my-dataset", meta)
         assert "alice/my-dataset" in card
 
+
+class TestWorkerResolution:
+    def test_resolve_export_workers_uses_shared_env(self, monkeypatch):
+        monkeypatch.setenv("DATACLAW_WORKERS", "3")
+
+        assert exporting_mod._resolve_export_workers(10) == 3
+
     def test_includes_model_and_project_tables_sorted_by_output_tokens(self):
         meta = {
             "model_breakdown": {

--- a/tests/test_cli_review.py
+++ b/tests/test_cli_review.py
@@ -2,6 +2,7 @@
 
 import json
 
+from dataclaw._cli import review as review_mod
 from dataclaw._cli.review import (
     _collect_review_attestations,
     _scan_export_review,
@@ -14,6 +15,11 @@ from dataclaw._cli.review import (
 
 
 class TestAttestationHelpers:
+    def test_resolve_review_workers_uses_shared_env(self, monkeypatch):
+        monkeypatch.setenv("DATACLAW_WORKERS", "3")
+
+        assert review_mod._resolve_review_workers(32 * 1024 * 1024) == 3
+
     def test_collect_review_attestations_valid(self):
         attestations, errors, manual_count = _collect_review_attestations(
             attest_asked_full_name="I asked Jane Doe for their full name and scanned the export for Jane Doe.",

--- a/tests/test_cli_review.py
+++ b/tests/test_cli_review.py
@@ -4,6 +4,7 @@ import json
 
 from dataclaw._cli.review import (
     _collect_review_attestations,
+    _scan_export_review,
     _scan_for_text_occurrences,
     _scan_high_entropy_strings,
     _scan_pii,
@@ -221,6 +222,41 @@ class TestScanPiiHighEntropy:
 
 
 class TestConfirmStreaming:
+    def test_scan_export_review_parallel_matches_serial(self, tmp_path, monkeypatch):
+        export_file = tmp_path / "export.jsonl"
+        export_file.write_text(
+            "".join(
+                [
+                    '{"project":"proj-a","model":"model-a","message":"Jane Doe","messages":[]}\n',
+                    '{"project":"proj-b","model":"model-b","message":"contact jane@example.com","messages":[]}\n',
+                    '{"project":"proj-a","model":"model-a","message":"token aB3dE6gH9jK2mN5pQ8rS1tU4wX7yZ0c","messages":[]}\n',
+                    '{"project":"proj-c","model":"model-c","message":"Jane Doe again","messages":[]}\n',
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        class FakeExecutor:
+            def __init__(self, max_workers):
+                self.max_workers = max_workers
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def map(self, fn, payloads, chunksize=1):
+                del chunksize
+                return [fn(payload) for payload in payloads]
+
+        monkeypatch.setattr("dataclaw._cli.review.ProcessPoolExecutor", FakeExecutor)
+
+        serial = _scan_export_review(export_file, full_name_query="Jane Doe", workers=1)
+        parallel = _scan_export_review(export_file, full_name_query="Jane Doe", workers=2)
+
+        assert parallel == serial
+
     def test_confirm_reviews_export_in_single_pass(self, tmp_path, monkeypatch, capsys):
         export_file = tmp_path / "export.jsonl"
         export_file.write_text(
@@ -228,6 +264,7 @@ class TestConfirmStreaming:
             '{"project":"proj-b","model":"model-b","message":"contact jane@example.com","messages":[]}\n',
             encoding="utf-8",
         )
+        perf_counter_values = iter([10.0, 11.5])
 
         open_calls = 0
         real_open = open
@@ -239,6 +276,7 @@ class TestConfirmStreaming:
             return real_open(file, *args, **kwargs)
 
         monkeypatch.setattr("builtins.open", counting_open)
+        monkeypatch.setattr("dataclaw._cli.review.time.perf_counter", lambda: next(perf_counter_values))
 
         saved_config = {}
         confirm(
@@ -255,6 +293,7 @@ class TestConfirmStreaming:
         )
 
         payload = json.loads(capsys.readouterr().out)
+        assert payload["elapsed"] == "1.50s"
         assert payload["total_sessions"] == 2
         assert payload["full_name_scan"]["match_count"] == 1
         assert payload["pii_scan"]["emails"] == ["jane@example.com"]

--- a/tests/test_jsonl_tools.py
+++ b/tests/test_jsonl_tools.py
@@ -67,6 +67,22 @@ class TestSimplifyPatchOps:
         assert result == [{"op": "add", "path": "/messages/0/tool_uses/0/output/raw", "value": {"type": "text"}}]
 
 
+class TestBuildTextReplaceDiff:
+    def test_limits_context_to_three_surrounding_lines(self):
+        old = "\n".join(f"line {idx}" for idx in range(1, 11))
+        new = old.replace("line 6", "updated line 6")
+
+        diff = jsonl_tools.build_text_replace_diff(old, new)
+
+        assert diff is not None
+        assert "line 3" in diff
+        assert "line 9" in diff
+        assert "line 2" not in diff
+        assert "line 10" not in diff
+        assert "-line 6" in diff
+        assert "+updated line 6" in diff
+
+
 class TestDiffJsonlFiles:
     def test_writes_yaml_summary_and_patch(self, tmp_path, monkeypatch):
         old_path = tmp_path / "old.jsonl"
@@ -120,7 +136,7 @@ class TestDiffJsonlFiles:
         assert b"\r\n" not in raw
         assert b"\n" in raw
 
-    def test_skips_jd_for_large_blob_replacements(self, tmp_path, monkeypatch):
+    def test_localizes_large_blob_replacements(self, tmp_path, monkeypatch):
         old_path = tmp_path / "old.jsonl"
         new_path = tmp_path / "new.jsonl"
         output_path = tmp_path / "diff.yaml"
@@ -142,10 +158,21 @@ class TestDiffJsonlFiles:
             encoding="utf-8",
         )
 
-        def fail_run_jd_patch(_old, _new):
-            raise AssertionError("run_jd_patch should not be called for large blob diffs")
+        captured = {}
 
-        monkeypatch.setattr("dataclaw.jsonl_tools.run_jd_patch", fail_run_jd_patch)
+        def fake_run_jd_patch(old_obj, new_obj):
+            captured["old_obj"] = old_obj
+            captured["new_obj"] = new_obj
+            return [
+                {
+                    "op": "replace",
+                    "path": "/messages/0/content_parts/0/source/data",
+                    "old": old_obj["messages"][0]["content_parts"][0]["source"]["data"],
+                    "new": new_obj["messages"][0]["content_parts"][0]["source"]["data"],
+                }
+            ]
+
+        monkeypatch.setattr("dataclaw.jsonl_tools.run_jd_patch", fake_run_jd_patch)
 
         result = jsonl_tools.diff_jsonl_files(old_path, new_path, output_path)
 
@@ -153,8 +180,15 @@ class TestDiffJsonlFiles:
         docs = list(yaml.safe_load_all(output_path.read_text(encoding="utf-8")))
         patch = docs[1]["patch"]
         assert patch[0]["op"] == "replace_large_blob"
-        assert patch[0]["old"]["messages"][0]["content_parts"][0]["source"]["data"]["type"] == "large_blob"
-        assert patch[0]["new"]["messages"][0]["content_parts"][0]["source"]["data"]["length"] == len(new_blob)
+        assert patch[0]["path"] == "/messages/0/content_parts/0/source/data"
+        assert patch[0]["old"] == {"type": "large_blob", "length": len(old_blob)}
+        assert patch[0]["new"] == {"type": "large_blob", "length": len(new_blob)}
+        assert captured["old_obj"]["messages"][0]["content_parts"][0]["source"]["data"].startswith(
+            "__DATACLAW_LARGE_BLOB__:"
+        )
+        assert captured["new_obj"]["messages"][0]["content_parts"][0]["source"]["data"].startswith(
+            "__DATACLAW_LARGE_BLOB__:"
+        )
 
     def test_handles_duplicate_identity_records_with_multiple_modifications(self, tmp_path, monkeypatch):
         old_path = tmp_path / "old.jsonl"

--- a/tests/test_jsonl_tools.py
+++ b/tests/test_jsonl_tools.py
@@ -1,5 +1,6 @@
 """Tests for JSONL formatting and diff helpers."""
 
+from concurrent.futures import Future
 from pathlib import Path
 
 import yaml
@@ -29,6 +30,11 @@ class TestJsonlToYamlFile:
         raw = output_path.read_bytes()
         assert b"\r\n" not in raw
         assert b"\n" in raw
+
+    def test_resolve_diff_workers_uses_shared_env(self, monkeypatch):
+        monkeypatch.setenv("DATACLAW_WORKERS", "3")
+
+        assert jsonl_tools._resolve_diff_workers(10) == 3
 
 
 class TestSimplifyPatchOps:
@@ -189,6 +195,70 @@ class TestDiffJsonlFiles:
         assert captured["new_obj"]["messages"][0]["content_parts"][0]["source"]["data"].startswith(
             "__DATACLAW_LARGE_BLOB__:"
         )
+
+    def test_parallel_patch_generation_preserves_event_order(self, tmp_path, monkeypatch):
+        old_path = tmp_path / "old.jsonl"
+        new_path = tmp_path / "new.jsonl"
+        output_path = tmp_path / "diff.yaml"
+
+        old_path.write_text(
+            '{"source":"claude","project":"proj","session_id":"s1","start_time":"2026-01-01T00:00:00Z","messages":[{"role":"assistant","timestamp":"2026-01-01T00:00:00Z","content":"old-a"}]}\n'
+            '{"source":"claude","project":"proj","session_id":"s2","start_time":"2026-01-01T00:00:01Z","messages":[{"role":"assistant","timestamp":"2026-01-01T00:00:01Z","content":"old-b"}]}\n',
+            encoding="utf-8",
+        )
+        new_path.write_text(
+            '{"source":"claude","project":"proj","session_id":"s1","start_time":"2026-01-01T00:00:00Z","messages":[{"role":"assistant","timestamp":"2026-01-01T00:00:00Z","content":"new-a"}]}\n'
+            '{"source":"claude","project":"proj","session_id":"s2","start_time":"2026-01-01T00:00:01Z","messages":[{"role":"assistant","timestamp":"2026-01-01T00:00:01Z","content":"new-b"}]}\n',
+            encoding="utf-8",
+        )
+
+        captured = {}
+
+        class FakeExecutor:
+            def __init__(self, max_workers):
+                captured["max_workers"] = max_workers
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            def map(self, fn, payloads):
+                payload_list = list(payloads)
+                captured["payloads"] = payload_list
+                futures = []
+                for payload in payload_list:
+                    future = Future()
+                    future.set_result(fn(payload))
+                    futures.append(future)
+                return [future.result() for future in reversed(futures)][::-1]
+
+        def fake_run_jd_patch(old_obj, new_obj):
+            return [
+                {
+                    "op": "replace",
+                    "path": "/messages/0/content",
+                    "old": old_obj["messages"][0]["content"],
+                    "new": new_obj["messages"][0]["content"],
+                }
+            ]
+
+        monkeypatch.setattr("dataclaw.jsonl_tools.ThreadPoolExecutor", FakeExecutor)
+        monkeypatch.setattr("dataclaw.jsonl_tools.run_jd_patch", fake_run_jd_patch)
+
+        result = jsonl_tools.diff_jsonl_files(old_path, new_path, output_path, workers=2)
+
+        assert result.event_count == 2
+        assert captured["max_workers"] == 2
+        assert len(captured["payloads"]) == 2
+        docs = list(yaml.safe_load_all(output_path.read_text(encoding="utf-8")))
+        assert docs[1]["identity"]["session_id"] == "s1"
+        assert docs[1]["patch"][0]["old"] == "old-a"
+        assert docs[1]["patch"][0]["new"] == "new-a"
+        assert docs[2]["identity"]["session_id"] == "s2"
+        assert docs[2]["patch"][0]["old"] == "old-b"
+        assert docs[2]["patch"][0]["new"] == "new-b"
 
     def test_handles_duplicate_identity_records_with_multiple_modifications(self, tmp_path, monkeypatch):
         old_path = tmp_path / "old.jsonl"

--- a/tests/test_jsonl_tools.py
+++ b/tests/test_jsonl_tools.py
@@ -72,6 +72,102 @@ class TestSimplifyPatchOps:
 
         assert result == [{"op": "add", "path": "/messages/0/tool_uses/0/output/raw", "value": {"type": "text"}}]
 
+    def test_matches_remove_add_messages_with_same_timestamp_and_diffs_content(self, monkeypatch):
+        old_message = {
+            "role": "user",
+            "timestamp": "2026-01-01T00:00:00Z",
+            "content": "old request",
+        }
+        new_message = {
+            "role": "user",
+            "timestamp": "2026-01-01T00:00:00Z",
+            "content": "new request",
+        }
+
+        def fake_run_jd_patch(old_obj, new_obj):
+            if old_obj == old_message and new_obj == new_message:
+                return [{"op": "replace", "path": "/content", "old": "old request", "new": "new request"}]
+            raise AssertionError("Unexpected jd patch request")
+
+        monkeypatch.setattr("dataclaw.jsonl_tools.run_jd_patch", fake_run_jd_patch)
+
+        result = jsonl_tools.simplify_patch_ops(
+            [
+                {"op": "remove", "path": "/messages/19", "value": old_message},
+                {"op": "add", "path": "/messages/19", "value": new_message},
+            ]
+        )
+
+        assert result == [{"op": "replace", "path": "/messages/19/content", "old": "old request", "new": "new request"}]
+
+    def test_matches_remove_add_tool_uses_by_tool_and_structure(self, monkeypatch):
+        old_tool_use = {
+            "tool": "shell_command",
+            "input": {
+                "command": "sed -n '1,5p' file.py",
+                "workdir": "/tmp/project",
+            },
+            "output": {
+                "output": "old output",
+                "exit_code": 0,
+            },
+            "status": "success",
+        }
+        new_tool_use = {
+            "tool": "shell_command",
+            "input": {
+                "command": "sed -n '6,10p' file.py",
+                "workdir": "/tmp/project",
+            },
+            "output": {
+                "output": "new output",
+                "exit_code": 0,
+            },
+            "status": "success",
+        }
+
+        def fake_run_jd_patch(old_obj, new_obj):
+            if old_obj == old_tool_use and new_obj == new_tool_use:
+                return [
+                    {
+                        "op": "replace",
+                        "path": "/input/command",
+                        "old": "sed -n '1,5p' file.py",
+                        "new": "sed -n '6,10p' file.py",
+                    },
+                    {
+                        "op": "replace",
+                        "path": "/output/output",
+                        "old": "old output",
+                        "new": "new output",
+                    },
+                ]
+            raise AssertionError("Unexpected jd patch request")
+
+        monkeypatch.setattr("dataclaw.jsonl_tools.run_jd_patch", fake_run_jd_patch)
+
+        result = jsonl_tools.simplify_patch_ops(
+            [
+                {"op": "remove", "path": "/messages/1/tool_uses/20", "value": old_tool_use},
+                {"op": "add", "path": "/messages/1/tool_uses/20", "value": new_tool_use},
+            ]
+        )
+
+        assert result == [
+            {
+                "op": "replace",
+                "path": "/messages/1/tool_uses/20/input/command",
+                "old": "sed -n '1,5p' file.py",
+                "new": "sed -n '6,10p' file.py",
+            },
+            {
+                "op": "replace",
+                "path": "/messages/1/tool_uses/20/output/output",
+                "old": "old output",
+                "new": "new output",
+            },
+        ]
+
 
 class TestBuildTextReplaceDiff:
     def test_limits_context_to_three_surrounding_lines(self):


### PR DESCRIPTION
`export`, `confirm`, and `diff-jsonl` now use all CPU cores whenever available.